### PR TITLE
chore: update Node.js test matrix to use LTS versions 22 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["22", "23"]
+        node-version: ["22", "24"]
     services:
       redis:
         image: redis:7-alpine


### PR DESCRIPTION
## Summary
- Update the Node.js test matrix in CI workflow to use LTS versions 22 and 24 (replacing 23)