### PR TITLE
feat: add integration tests for spec compliance and RFC 7807 error responses

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -10,3 +10,4 @@ export {
 } from "./validation.js";
 export { withResilience } from "./resilience.js";
 export { DEFAULT_OPTIONS as defaultOptions } from "./default-options.js";
+export { conflictErrorResponse, missingKeyResponse } from "./problem-json.js";

--- a/packages/core/src/problem-json.js
+++ b/packages/core/src/problem-json.js
@@ -1,0 +1,35 @@
+/**
+ * RFC 7807 Problem Details for HTTP APIs
+ * @module problem-json
+ */
+
+/**
+ * Builds RFC 7807 problem+json error response for idempotency conflicts
+ * @param {number} status - HTTP status code (409 or 422)
+ * @param {string} error - Error message
+ * @returns {Object} RFC 7807 problem response
+ */
+export function conflictErrorResponse(status, error) {
+  const titles = {
+    409: "A request is outstanding for this Idempotency-Key",
+    422: "Idempotency-Key is already used"
+  };
+  return {
+    type: "https://developer.example.com/idempotency",
+    title: titles[status],
+    detail: error
+  };
+}
+
+/**
+ * Builds RFC 7807 problem+json error response for missing idempotency key
+ * @returns {Object} RFC 7807 problem response
+ */
+export function missingKeyResponse() {
+  return {
+    type: "https://developer.example.com/idempotency",
+    title: "Idempotency-Key is missing",
+    detail:
+      "This operation is idempotent and it requires correct usage of Idempotency Key."
+  };
+}

--- a/packages/core/tests/framework-adapter-suite.js
+++ b/packages/core/tests/framework-adapter-suite.js
@@ -135,7 +135,14 @@ export function runAdapterTests(adapter) {
     );
 
     t.equal(response.status, 400, "should return 400");
-    t.match(response.body?.error || JSON.stringify(response.body), /required/i);
+    t.match(
+      response.body?.type ||
+        response.body?.title ||
+        response.body?.detail ||
+        JSON.stringify(response.body),
+      /idempotency/i,
+      "should have idempotency-related error"
+    );
 
     await teardown();
   });

--- a/packages/frameworks/express/index.js
+++ b/packages/frameworks/express/index.js
@@ -9,7 +9,9 @@ import {
   getCachedResponse,
   prepareCachedResponse,
   withResilience,
-  defaultOptions
+  defaultOptions,
+  conflictErrorResponse,
+  missingKeyResponse
 } from "@idempot/core";
 
 /**
@@ -62,7 +64,10 @@ export function idempotency(options = {}) {
     const key = /** @type {string} */ (req.headers[HEADER_NAME]);
     if (key === undefined) {
       if (opts.required) {
-        res.status(400).json({ error: "Idempotency-Key header is required" });
+        res
+          .status(400)
+          .set("Content-Type", "application/problem+json")
+          .json(missingKeyResponse());
         return;
       }
       next();
@@ -97,7 +102,13 @@ export function idempotency(options = {}) {
     if (conflict.conflict) {
       res
         .status(/** @type {number} */ (conflict.status))
-        .json({ error: conflict.error });
+        .set("Content-Type", "application/problem+json")
+        .json(
+          conflictErrorResponse(
+            /** @type {number} */ (conflict.status),
+            conflict.error
+          )
+        );
       return;
     }
 

--- a/packages/frameworks/fastify/index.js
+++ b/packages/frameworks/fastify/index.js
@@ -8,7 +8,9 @@ import {
   getCachedResponse,
   prepareCachedResponse,
   withResilience,
-  defaultOptions
+  defaultOptions,
+  conflictErrorResponse,
+  missingKeyResponse
 } from "@idempot/core";
 
 const HEADER_NAME = "idempotency-key";
@@ -66,7 +68,8 @@ export function idempotency(options = {}) {
       if (opts.required) {
         return reply
           .code(400)
-          .send({ error: "Idempotency-Key header is required" });
+          .header("Content-Type", "application/problem+json")
+          .send(missingKeyResponse());
       }
       return;
     }
@@ -95,9 +98,12 @@ export function idempotency(options = {}) {
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
     if (conflict.conflict) {
+      const status = /** @type {409|422} */ (conflict.status);
+      const errorMsg = /** @type {string} */ (conflict.error);
       return reply
-        .code(/** @type {number} */ (conflict.status))
-        .send({ error: conflict.error });
+        .code(status)
+        .header("Content-Type", "application/problem+json")
+        .send(conflictErrorResponse(status, errorMsg));
     }
 
     const cached = getCachedResponse(lookup);
@@ -122,8 +128,10 @@ export function idempotency(options = {}) {
       requestMeta.set(request, { idempotencyKey: key });
 
       const originalSend = reply.send.bind(reply);
+      let capturedBody = "";
+
       reply.send = (payload) => {
-        const capturedBody =
+        capturedBody =
           typeof payload === "string" ? payload : JSON.stringify(payload);
         const meta = requestMeta.get(request);
         meta.idempotencyBody = capturedBody;

--- a/packages/frameworks/hono/index.js
+++ b/packages/frameworks/hono/index.js
@@ -8,7 +8,9 @@ import {
   getCachedResponse,
   prepareCachedResponse,
   withResilience,
-  defaultOptions
+  defaultOptions,
+  conflictErrorResponse,
+  missingKeyResponse
 } from "@idempot/core";
 
 /**
@@ -32,7 +34,7 @@ const HEADER_NAME = "idempotency-key";
  * @param {string} [opts.headerName="Idempotency-Key"] - Header name
  * @param {number} [opts.maxKeyLength=255] - Maximum key length
  * @param {number} [opts.minKeyLength=21] - Minimum key length (default: 21 for nanoid)
- * @returns {(c: any, next: any) => Promise<void>}
+ * @returns {(c: import("hono").Context, next: () => Promise<void>) => Promise<void>}
  */
 export function idempotency(options = {}) {
   const opts = { ...defaultOptions, ...options };
@@ -64,7 +66,9 @@ export function idempotency(options = {}) {
     const key = c.req.header(HEADER_NAME);
     if (key === undefined) {
       if (opts.required) {
-        return c.json({ error: "Idempotency-Key header is required" }, 400);
+        return c.json(missingKeyResponse(), 400, {
+          "Content-Type": "application/problem+json"
+        });
       }
       await next();
       return;
@@ -90,7 +94,11 @@ export function idempotency(options = {}) {
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
     if (conflict.conflict) {
-      return c.json({ error: conflict.error }, conflict.status);
+      const status = /** @type {409|422} */ (conflict.status);
+      const errorMsg = /** @type {string} */ (conflict.error);
+      return c.json(conflictErrorResponse(status, errorMsg), status, {
+        "Content-Type": "application/problem+json"
+      });
     }
 
     const cached = getCachedResponse(lookup);

--- a/tests/integration/express-mysql.test.js
+++ b/tests/integration/express-mysql.test.js
@@ -6,7 +6,7 @@ import {
   generateIdempotencyKey
 } from "./shared/shared-helpers.js";
 import { initMysqlSchema } from "./shared/mysql-helpers.js";
-import { makeRequest } from "./shared/request.js";
+import { makeRequest, makeRequestWithoutKey } from "./shared/request.js";
 import {
   createNodeMysqlStore,
   waitForIdempotencyRecordComplete
@@ -201,3 +201,52 @@ t.test("Express + MySQL - handles missing response_status", async (t) => {
     "should return undefined when response_status is NULL"
   );
 });
+
+t.test(
+  "Express + MySQL - returns 400 when Idempotency-Key header is missing",
+  async (t) => {
+    const { port } = t.context;
+
+    const response = await makeRequestWithoutKey(port, { foo: "bar" });
+
+    t.equal(response.status, 400, "should return 400");
+    t.match(
+      response.headers["content-type"],
+      /application\/problem\+json/,
+      "should return problem+json content type"
+    );
+    t.match(response.body.type, /idempotency/i, "should have type field");
+    t.match(response.body.title, /missing/i, "should indicate key is missing");
+  }
+);
+
+t.test(
+  "Express + MySQL - returns 422 when same key is used with different payload",
+  async (t) => {
+    const { port } = t.context;
+    const key = generateIdempotencyKey();
+
+    await makeRequest(port, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+
+    const response2 = await makeRequest(port, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+
+    t.equal(response2.status, 422, "should return 422");
+    t.match(
+      response2.headers["content-type"],
+      /application\/problem\+json/,
+      "should return problem+json content type"
+    );
+    t.match(response2.body.type, /idempotency/i, "should have type field");
+    t.match(
+      response2.body.title,
+      /already used|different/i,
+      "should indicate key is already used"
+    );
+  }
+);

--- a/tests/integration/fastify-sqlite.test.js
+++ b/tests/integration/fastify-sqlite.test.js
@@ -2,7 +2,7 @@ import t from "tap";
 import Fastify from "fastify";
 import { idempotency } from "../../packages/frameworks/fastify/index.js";
 import { createSqliteStore, cleanupSqlite } from "./shared/sqlite.js";
-import { makeRequest } from "./shared/request.js";
+import { makeRequest, makeRequestWithoutKey } from "./shared/request.js";
 
 function createFastifySqliteApp(store) {
   const app = Fastify();
@@ -132,5 +132,23 @@ t.test(
       1,
       "should only have one order despite two different idempotency keys (same fingerprint)"
     );
+  }
+);
+
+t.test(
+  "Fastify + SQLite - returns 400 when Idempotency-Key header is missing",
+  async (t) => {
+    const { port } = t.context;
+
+    const response = await makeRequestWithoutKey(port, { foo: "bar" });
+
+    t.equal(response.status, 400, "should return 400");
+    t.match(
+      response.headers["content-type"],
+      /application\/problem\+json/,
+      "should return problem+json content type"
+    );
+    t.match(response.body.type, /idempotency/i, "should have type field");
+    t.match(response.body.title, /missing/i, "should indicate key is missing");
   }
 );

--- a/tests/integration/hono-postgres.test.js
+++ b/tests/integration/hono-postgres.test.js
@@ -10,7 +10,7 @@ import {
   generateTestId,
   generateIdempotencyKey
 } from "./shared/shared-helpers.js";
-import { makeRequest } from "./shared/request.js";
+import { makeRequest, makeRequestWithoutKey } from "./shared/request.js";
 import {
   createPostgresStore,
   waitForIdempotencyRecordComplete
@@ -157,6 +157,39 @@ t.test(
       orders.rows.length,
       1,
       "should only have one order despite two different idempotency keys (same fingerprint)"
+    );
+  }
+);
+
+t.test(
+  "Hono + Postgres - returns 422 when same key is used with different payload",
+  async (t) => {
+    const { store, port, schema } = t.context;
+    const key = generateIdempotencyKey();
+
+    await makeRequest(port, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+
+    await waitForIdempotencyRecordComplete(store, schema, key);
+
+    const response2 = await makeRequest(port, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+
+    t.equal(response2.status, 422, "should return 422");
+    t.equal(
+      response2.headers["content-type"],
+      "application/problem+json",
+      "should return problem+json content type"
+    );
+    t.match(response2.body.type, /idempotency/i, "should have type field");
+    t.match(
+      response2.body.title,
+      /already used|different/i,
+      "should indicate key is already used"
     );
   }
 );

--- a/tests/integration/shared/request.js
+++ b/tests/integration/shared/request.js
@@ -30,3 +30,33 @@ export async function makeRequest(port, options) {
     req.end();
   });
 }
+
+export async function makeRequestWithoutKey(port, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "localhost",
+        port,
+        path: "/api",
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        }
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: JSON.parse(data)
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(JSON.stringify(body));
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary

Adds integration tests for spec compliance and updates error responses to follow RFC 7807 problem+json format.

## Changes

### Integration Tests
- Added tests for 400 (missing idempotency key) in Express+MySQL and Fastify+SQLite
- Added tests for 422 (key reused with different payload) in Express+MySQL and Hono+Postgres  
- All new tests verify RFC 7807 problem+json response format
- Added `makeRequestWithoutKey` helper for testing missing header scenarios

### Framework Updates
- Updated Express, Hono, and Fastify frameworks to return RFC 7807 compliant error responses
- Error responses now include `type`, `title`, and `detail` fields
- Extracted `conflictErrorResponse` and `missingKeyResponse` to `@idempot/core` package to reduce duplication

### Spec Coverage
This addresses SPEC.md Section 2.7 Error Handling requirements:
- 400 Bad Request when Idempotency-Key header is missing
- 422 Unprocessable Content when key is reused with different payload
- 409 Conflict for concurrent requests (pre-existing)

## Testing
- All new integration tests pass
- Full test suite passes with 100% coverage