### PR TITLE
ci: gate test jobs on lint and commitlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
   test:
     name: Test (Node.js ${{ matrix.node-version }})
+    needs: [lint, commitlint]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -111,6 +112,7 @@ jobs:
 
   bun:
     name: Bun
+    needs: [lint, commitlint]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -156,6 +158,7 @@ jobs:
 
   deno:
     name: Deno
+    needs: [lint, commitlint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ This library adds **request fingerprinting** to detect conflicts when the same i
 
 ## Runtime vs Storage Support
 
-| Store    | Node | Bun | Deno |
-| -------- | ---- | --- | ---- |
-| Redis    | ✅   | ✅  | ✅   |
-| Postgres | ✅   | ✅  | ✅   |
-| MySQL    | ✅   | ✅  | ✅   |
-| SQLite   | ✅   | ✅  | ✅   |
+| Runtime | Redis | Postgres | MySQL | SQLite |
+| ------- | ----- | -------- | ----- | ------ |
+| Node    | ✅    | ✅       | ✅    | ✅     |
+| Bun     | ✅    | ✅       | ✅    | ✅     |
+| Deno    | ✅    | ✅       | ✅    | ✅     |
 
 ✅ = Supported | 🔄 = Untested (contributions welcome) | ❌ = Not supported
 


### PR DESCRIPTION
## Summary
- Add `needs: [lint, commitlint]` to Node.js, Bun, and Deno test jobs
- Test jobs now wait for both lint and commitlint to pass before starting, avoiding wasted compute on infrastructure spin-up when lint or commit messages fail