### PR TITLE
docs: add LICENSE and README to all packages, document core as internal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,6 +64,19 @@ idempot-js/
 
 The core package contains the framework-agnostic idempotency logic. All framework adapters use these core functions.
 
+**Important:** `@idempot/core` is an **internal shared package**, not a user-facing package. Users should never install or import from it directly.
+
+- **Users install:** Framework packages (`@idempot/hono-middleware`, `@idempot/express-middleware`) and store packages (`@idempot/sqlite-store`, `@idempot/redis-store`)
+- **Core is:** A transitive dependency that framework and store packages use internally
+
+```
+User Application
+       │
+       ├─► @idempot/hono-middleware ──► @idempot/core (transitive)
+       │                                      │
+       └─► @idempot/sqlite-store ──────► @idempot/core (transitive)
+```
+
 ### fingerprint.js
 
 Generates a deterministic fingerprint from the request body. This fingerprint detects when the same idempotency key is used with different payloads.
@@ -390,11 +403,14 @@ The containers use arm64 architecture (native to Apple Silicon) to avoid Rosetta
 
 ### Adding a New Storage Backend
 
-1. Implement `IdempotencyStore` interface
-2. Follow existing patterns (see `packages/stores/sqlite/`)
-3. Write unit tests
-4. Add to `examples/` directory
-5. Update README with backend matrix
+1. Copy the `IdempotencyStore` interface pattern from an existing store (e.g., `packages/stores/sqlite/index.js`)
+2. Implement all methods: `lookup`, `startProcessing`, `complete`, `close`
+3. Follow existing patterns (see `packages/stores/sqlite/` for a reference implementation)
+4. Write unit tests using the shared test patterns
+5. Add to `examples/` directory
+6. Update README with backend matrix
+
+**Note:** Do not import `IdempotencyStore` from `@idempot/core`. Define the interface locally in your store implementation, matching the pattern used by existing stores.
 
 ### Adding a New Framework Adapter
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ console.log(middleware.circuit.status); // 'closed', 'open', 'half-open'
 ## Quick Start
 
 ```bash
-npm install @idempot/core @idempot/hono-middleware @idempot/sqlite-store
+npm install @idempot/hono-middleware @idempot/sqlite-store
 ```
 
 ```javascript

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,48 @@
+# @idempot/core
+
+**Internal shared package. Do not use directly.**
+
+This package contains framework-agnostic idempotency logic used internally by framework adapters and storage backends. It is published as a transitive dependency only.
+
+## For End Users
+
+You should not install or import from this package directly. Instead, use the framework and store packages:
+
+```bash
+# Correct: Install framework and store packages
+npm install @idempot/hono-middleware @idempot/sqlite-store
+
+# Incorrect: Do not install core directly
+npm install @idempot/core  # ❌
+```
+
+```javascript
+// Correct: Import from framework package
+import { idempotency } from "@idempot/hono-middleware";
+
+// Incorrect: Do not import from core
+import { generateFingerprint } from "@idempot/core"; // ❌
+```
+
+## For Package Maintainers
+
+Framework adapters and storage backends depend on this package for:
+
+- Request fingerprinting (`generateFingerprint`)
+- Validation logic (`validateIdempotencyKey`, `checkLookupConflicts`)
+- Resilience patterns (`withResilience`)
+- Default configuration (`defaultOptions`)
+- Store interface definition (`IdempotencyStore`)
+
+### Design Constraints
+
+This package **must not** export anything intended for direct user consumption. All exports are for internal use by:
+
+1. Framework adapters (`@idempot/hono-middleware`, `@idempot/express-middleware`, `@idempot/fastify-middleware`)
+2. Storage backends (`@idempot/sqlite-store`, `@idempot/redis-store`, etc.)
+
+TypeScript types are bundled into framework and store packages, so users can access them without importing from core.
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,4 +45,4 @@ TypeScript types are bundled into framework and store packages, so users can acc
 
 ## License
 
-MIT
+BSD-3-Clause

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap tests/"

--- a/packages/frameworks/express/LICENSE
+++ b/packages/frameworks/express/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/frameworks/express/README.md
+++ b/packages/frameworks/express/README.md
@@ -1,0 +1,50 @@
+# @idempot/express-middleware
+
+Express middleware for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/express-middleware @idempot/sqlite-store
+```
+
+## Usage
+
+```javascript
+import express from "express";
+import { idempotency } from "@idempot/express-middleware";
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+const app = express();
+const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+app.use(express.json());
+
+app.post("/orders", idempotency({ store }), async (req, res) => {
+  const orderId = crypto.randomUUID();
+  res.status(201).json({ id: orderId, ...req.body });
+});
+
+app.listen(3000);
+```
+
+## API
+
+### `idempotency(options)`
+
+Creates Express middleware for idempotency.
+
+**Options:**
+
+- `store` (required): Storage backend implementing `IdempotencyStore`
+- `headerName`: Header name for idempotency key (default: `"Idempotency-Key"`)
+- `required`: Whether idempotency key is required (default: `false`)
+- `ttlMs`: Time-to-live for idempotency records in milliseconds
+- `excludeFields`: Fields to exclude from fingerprint calculation
+- `resilience`: Circuit breaker and retry options
+
+**Returns:** Express middleware function with `circuit` property for monitoring.
+
+## License
+
+BSD-3-Clause

--- a/packages/frameworks/express/package.json
+++ b/packages/frameworks/express/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap express-middleware.test.js"

--- a/packages/frameworks/fastify/LICENSE
+++ b/packages/frameworks/fastify/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/frameworks/fastify/README.md
+++ b/packages/frameworks/fastify/README.md
@@ -1,0 +1,52 @@
+# @idempot/fastify-middleware
+
+Fastify middleware for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/fastify-middleware @idempot/sqlite-store
+```
+
+## Usage
+
+```javascript
+import Fastify from "fastify";
+import { idempotency } from "@idempot/fastify-middleware";
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+const fastify = Fastify();
+const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+fastify.post(
+  "/orders",
+  { preHandler: idempotency({ store }) },
+  async (request, reply) => {
+    const orderId = crypto.randomUUID();
+    return { id: orderId, ...request.body };
+  }
+);
+
+fastify.listen({ port: 3000 });
+```
+
+## API
+
+### `idempotency(options)`
+
+Creates Fastify preHandler hook for idempotency.
+
+**Options:**
+
+- `store` (required): Storage backend implementing `IdempotencyStore`
+- `headerName`: Header name for idempotency key (default: `"Idempotency-Key"`)
+- `required`: Whether idempotency key is required (default: `false`)
+- `ttlMs`: Time-to-live for idempotency records in milliseconds
+- `excludeFields`: Fields to exclude from fingerprint calculation
+- `resilience`: Circuit breaker and retry options
+
+**Returns:** Fastify preHandler hook function with `circuit` property for monitoring.
+
+## License
+
+BSD-3-Clause

--- a/packages/frameworks/fastify/package.json
+++ b/packages/frameworks/fastify/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap fastify-middleware.test.js"

--- a/packages/frameworks/hono/LICENSE
+++ b/packages/frameworks/hono/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/frameworks/hono/README.md
+++ b/packages/frameworks/hono/README.md
@@ -1,0 +1,48 @@
+# @idempot/hono-middleware
+
+Hono middleware for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/hono-middleware @idempot/sqlite-store
+```
+
+## Usage
+
+```javascript
+import { Hono } from "hono";
+import { idempotency } from "@idempot/hono-middleware";
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+const app = new Hono();
+const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+app.post("/orders", idempotency({ store }), async (c) => {
+  const orderId = crypto.randomUUID();
+  return c.json({ id: orderId, ...(await c.req.json()) }, 201);
+});
+
+export default app;
+```
+
+## API
+
+### `idempotency(options)`
+
+Creates Hono middleware for idempotency.
+
+**Options:**
+
+- `store` (required): Storage backend implementing `IdempotencyStore`
+- `headerName`: Header name for idempotency key (default: `"Idempotency-Key"`)
+- `required`: Whether idempotency key is required (default: `false`)
+- `ttlMs`: Time-to-live for idempotency records in milliseconds
+- `excludeFields`: Fields to exclude from fingerprint calculation
+- `resilience`: Circuit breaker and retry options
+
+**Returns:** Hono middleware function with `circuit` property for monitoring.
+
+## License
+
+BSD-3-Clause

--- a/packages/frameworks/hono/package.json
+++ b/packages/frameworks/hono/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap hono-middleware.test.js"

--- a/packages/stores/bun-sql/LICENSE
+++ b/packages/stores/bun-sql/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/bun-sql/README.md
+++ b/packages/stores/bun-sql/README.md
@@ -85,3 +85,7 @@ export default {
 ## Requirements
 
 - Bun runtime (uses `bun:sqlite` and `bun` package for SQL)
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/bun-sql/package.json
+++ b/packages/stores/bun-sql/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "echo 'Skipping tests - run with bun test runtime-tests/bun/' && exit 0"

--- a/packages/stores/deno-mysql/LICENSE
+++ b/packages/stores/deno-mysql/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/deno-mysql/README.md
+++ b/packages/stores/deno-mysql/README.md
@@ -1,0 +1,98 @@
+# @idempot/deno-mysql-store
+
+MySQL storage backend for idempotency (Deno).
+
+## Installation
+
+Import directly from the repository:
+
+```typescript
+import { DenoMysqlIdempotencyStore } from "https://raw.githubusercontent.com/idempot-dev/idempot-js/main/packages/stores/deno-mysql/deno-mysql.js";
+```
+
+Or use with a specific version tag:
+
+```typescript
+import { DenoMysqlIdempotencyStore } from "https://raw.githubusercontent.com/idempot-dev/idempot-js/v0.1.0/packages/stores/deno-mysql/deno-mysql.js";
+```
+
+## Usage
+
+```typescript
+import { DenoMysqlIdempotencyStore } from "./deno-mysql.js";
+import { idempotencyMiddleware } from "https://raw.githubusercontent.com/idempot-dev/idempot-js/main/packages/frameworks/hono/index.js";
+
+const store = new DenoMysqlIdempotencyStore({
+  hostname: "127.0.0.1",
+  port: 3306,
+  username: "root",
+  password: "password",
+  db: "myapp"
+});
+
+await store.connect();
+
+// Use with Hono
+app.use("/api/*", idempotencyMiddleware({ store }));
+
+// Close on shutdown
+Deno.addSignalListener("SIGINT", async () => {
+  await store.close();
+  Deno.exit(0);
+});
+```
+
+## Schema
+
+The store creates a table named `idempotency_records` with:
+
+- `key` (VARCHAR(255), PRIMARY KEY)
+- `fingerprint` (VARCHAR(255), indexed)
+- `status` (VARCHAR(50): 'processing' or 'complete')
+- `response_status` (INT)
+- `response_headers` (TEXT, JSON)
+- `response_body` (TEXT)
+- `expires_at` (BIGINT, indexed)
+
+## API
+
+### `new DenoMysqlIdempotencyStore(options)`
+
+Creates a new MySQL store for Deno.
+
+**Options:**
+
+- `hostname`: MySQL hostname (default: `"127.0.0.1"`)
+- `port`: MySQL port (default: `3306`)
+- `username`: MySQL username (default: `"root"`)
+- `password`: MySQL password (default: `""`)
+- `db`: Database name (default: `"mysql"`)
+- `poolSize`: Connection pool size (default: `3`)
+
+### `await store.connect()`
+
+Connect to the database and initialize the schema. Must be called before use.
+
+### `await store.lookup(key, fingerprint)`
+
+Look up an idempotency record by key and fingerprint. Returns `{byKey, byFingerprint}`.
+
+### `await store.startProcessing(key, fingerprint, ttlMs)`
+
+Mark a request as being processed. Creates a new record with status `'processing'`.
+
+### `await store.complete(key, response)`
+
+Mark a request as complete with its response data. Updates the record with status `'complete'`.
+
+### `await store.close()`
+
+Close the database connection.
+
+## Deno Compatibility
+
+This package is designed for Deno runtime only. For Node.js, use `@idempot/node-mysql-store` instead.
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/node-mysql/LICENSE
+++ b/packages/stores/node-mysql/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/node-mysql/README.md
+++ b/packages/stores/node-mysql/README.md
@@ -1,0 +1,73 @@
+# @idempot/node-mysql-store
+
+MySQL storage backend for idempotency (Node.js).
+
+## Installation
+
+```bash
+npm install @idempot/node-mysql-store mysql2
+```
+
+## Usage
+
+```javascript
+import { NodeMysqlIdempotencyStore } from "@idempot/node-mysql-store";
+import mysql from "mysql2/promise";
+
+const pool = mysql.createPool({
+  host: "localhost",
+  database: "myapp",
+  user: "root",
+  password: "password"
+});
+
+const store = new NodeMysqlIdempotencyStore({ pool });
+
+// Close on shutdown
+process.on("SIGINT", async () => {
+  await store.close();
+  process.exit(0);
+});
+```
+
+## Schema
+
+The store creates a table named `idempotency_records` with:
+
+- `key` (VARCHAR(255), PRIMARY KEY)
+- `fingerprint` (VARCHAR(64), indexed)
+- `status` (ENUM: 'processing', 'complete')
+- `response_status` (INT)
+- `response_headers` (JSON)
+- `response_body` (TEXT)
+- `expires_at` (BIGINT, indexed)
+
+## API
+
+### `new NodeMysqlIdempotencyStore(options)`
+
+Creates a new MySQL store.
+
+**Options:**
+
+- `pool`: MySQL connection pool (from `mysql2` package)
+
+### `store.lookup(key, fingerprint)`
+
+Look up an idempotency record by key and fingerprint. Returns `{byKey, byFingerprint}`.
+
+### `store.startProcessing(key, fingerprint, ttlMs)`
+
+Mark a request as being processed. Creates a new record with status `'processing'`.
+
+### `store.complete(key, response)`
+
+Mark a request as complete with its response data. Updates the record with status `'complete'`.
+
+### `store.close()`
+
+Close the connection pool.
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/node-mysql/package.json
+++ b/packages/stores/node-mysql/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap tests/"

--- a/packages/stores/postgres/LICENSE
+++ b/packages/stores/postgres/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/postgres/README.md
+++ b/packages/stores/postgres/README.md
@@ -1,0 +1,73 @@
+# @idempot/postgres-store
+
+PostgreSQL storage backend for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/postgres-store pg
+```
+
+## Usage
+
+```javascript
+import { PostgresIdempotencyStore } from "@idempot/postgres-store";
+import { Pool } from "pg";
+
+const pool = new Pool({
+  host: "localhost",
+  database: "myapp",
+  user: "postgres",
+  password: "postgres"
+});
+
+const store = new PostgresIdempotencyStore({ pool });
+
+// Close on shutdown
+process.on("SIGINT", async () => {
+  await store.close();
+  process.exit(0);
+});
+```
+
+## Schema
+
+The store creates a table named `idempotency_records` with:
+
+- `key` (TEXT, PRIMARY KEY)
+- `fingerprint` (TEXT, indexed)
+- `status` (TEXT: 'processing' or 'complete')
+- `response_status` (INTEGER)
+- `response_headers` (JSONB)
+- `response_body` (TEXT)
+- `expires_at` (TIMESTAMP, indexed)
+
+## API
+
+### `new PostgresIdempotencyStore(options)`
+
+Creates a new PostgreSQL store.
+
+**Options:**
+
+- `pool`: PostgreSQL connection pool (from `pg` package)
+
+### `store.lookup(key, fingerprint)`
+
+Look up an idempotency record by key and fingerprint. Returns `{byKey, byFingerprint}`.
+
+### `store.startProcessing(key, fingerprint, ttlMs)`
+
+Mark a request as being processed. Creates a new record with status `'processing'`.
+
+### `store.complete(key, response)`
+
+Mark a request as complete with its response data. Updates the record with status `'complete'`.
+
+### `store.close()`
+
+Close the connection pool.
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/postgres/package.json
+++ b/packages/stores/postgres/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap tests/"

--- a/packages/stores/redis/LICENSE
+++ b/packages/stores/redis/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/redis/README.md
+++ b/packages/stores/redis/README.md
@@ -1,0 +1,79 @@
+# @idempot/redis-store
+
+Redis storage backend for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/redis-store ioredis
+```
+
+## Usage
+
+```javascript
+import { RedisIdempotencyStore } from "@idempot/redis-store";
+import Redis from "ioredis";
+
+const redis = new Redis();
+const store = new RedisIdempotencyStore({ client: redis });
+
+// Or with prefix
+const store = new RedisIdempotencyStore({
+  client: redis,
+  prefix: "myapp:idempotency:"
+});
+
+// Close on shutdown
+process.on("SIGINT", async () => {
+  await store.close();
+  process.exit(0);
+});
+```
+
+## API
+
+### `new RedisIdempotencyStore(options)`
+
+Creates a new Redis store.
+
+**Options:**
+
+- `client`: Redis client instance (ioredis)
+- `prefix`: Key prefix (default: `"idempotency:"`)
+
+### `store.lookup(key, fingerprint)`
+
+Look up an idempotency record by key and fingerprint. Returns `{byKey, byFingerprint}`.
+
+### `store.startProcessing(key, fingerprint, ttlMs)`
+
+Mark a request as being processed. Creates a new record with status `'processing'`.
+
+### `store.complete(key, response)`
+
+Mark a request as complete with its response data. Updates the record with status `'complete'`.
+
+### `store.close()`
+
+Close the Redis connection.
+
+## Persistence
+
+Ensure Redis persistence is configured (AOF recommended). See [Redis persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/).
+
+## Deno Support
+
+For Deno, use `DenoRedisIdempotencyStore`:
+
+```javascript
+import { DenoRedisIdempotencyStore } from "@idempot/redis-store/deno-redis.js";
+
+const store = new DenoRedisIdempotencyStore({
+  hostname: "127.0.0.1",
+  port: 6379
+});
+```
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/redis/README.md
+++ b/packages/stores/redis/README.md
@@ -59,7 +59,7 @@ Close the Redis connection.
 
 ## Persistence
 
-Ensure Redis persistence is configured (AOF recommended). See [Redis persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/).
+Ensure Redis persistence is configured (AOF strongly recommended). See [Redis persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/).
 
 ## Deno Support
 

--- a/packages/stores/redis/package.json
+++ b/packages/stores/redis/package.json
@@ -29,7 +29,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap tests/"

--- a/packages/stores/sqlite/LICENSE
+++ b/packages/stores/sqlite/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/stores/sqlite/README.md
+++ b/packages/stores/sqlite/README.md
@@ -1,0 +1,67 @@
+# @idempot/sqlite-store
+
+SQLite storage backend for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/sqlite-store better-sqlite3
+```
+
+## Usage
+
+```javascript
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+// In-memory (development)
+const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+// Persistent file
+const store = new SqliteIdempotencyStore({ path: "./idempotency.db" });
+
+// Close on shutdown
+process.on("SIGINT", () => {
+  store.close();
+  process.exit(0);
+});
+```
+
+## API
+
+### `new SqliteIdempotencyStore(options)`
+
+Creates a new SQLite store.
+
+**Options:**
+
+- `path`: Database path (default: `"./idempotency.db"`, use `":memory:"` for in-memory)
+
+### `store.lookup(key, fingerprint)`
+
+Look up an idempotency record by key and fingerprint. Returns `{byKey, byFingerprint}`.
+
+### `store.startProcessing(key, fingerprint, ttlMs)`
+
+Mark a request as being processed. Creates a new record with status `'processing'`.
+
+### `store.complete(key, response)`
+
+Mark a request as complete with its response data. Updates the record with status `'complete'`.
+
+### `store.close()`
+
+Close the database connection. Call this on shutdown.
+
+## Deno Support
+
+For Deno, use `DenoSqliteIdempotencyStore`:
+
+```javascript
+import { DenoSqliteIdempotencyStore } from "@idempot/sqlite-store/deno-sqlite.js";
+
+const store = new DenoSqliteIdempotencyStore({ path: "./idempotency.db" });
+```
+
+## License
+
+BSD-3-Clause

--- a/packages/stores/sqlite/package.json
+++ b/packages/stores/sqlite/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/idempot-dev/idempot-js"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "build": "tsc",
     "test": "tap tests/"


### PR DESCRIPTION
## Summary

- Updated all package.json files to use BSD-3-Clause license (was incorrectly MIT)
- Added LICENSE file (BSD-3-Clause) to all 9 packages
- Added README.md to all packages documenting usage, API, and installation
- Updated ARCHITECTURE.md to clarify that `@idempot/core` is internal-only
- Updated root README.md to remove `@idempot/core` from install examples

## Packages updated

**Core:**
- `packages/core/` - Added LICENSE, README (documents internal-only status)

**Frameworks:**
- `packages/frameworks/express/` - Added LICENSE, README
- `packages/frameworks/fastify/` - Added LICENSE, README
- `packages/frameworks/hono/` - Added LICENSE, README

**Stores:**
- `packages/stores/sqlite/` - Added LICENSE, README
- `packages/stores/redis/` - Added LICENSE, README
- `packages/stores/postgres/` - Added LICENSE, README
- `packages/stores/node-mysql/` - Added LICENSE, README
- `packages/stores/bun-sql/` - Added LICENSE, README
- `packages/stores/deno-mysql/` - Added LICENSE, README (standalone Deno package)

## License consistency

All package.json files had `"license": "MIT"` but the root LICENSE is BSD-3-Clause. Updated all to `"license": "BSD-3-Clause"` for consistency.