### PR TITLE
docs(bun-sql): add CONTRIBUTING.md with test location

### DIFF
--- a/packages/stores/bun-sql/CONTRIBUTING.md
+++ b/packages/stores/bun-sql/CONTRIBUTING.md
@@ -6,11 +6,11 @@ Tests for this package are located in the monorepo root at `tests/runtime/bun/`,
 
 ### Test Files
 
-| File | Purpose |
-|------|---------|
-| `tests/runtime/bun/bun-sql.test.js` | Unit tests forBunSqlIdempotencyStore |
+| File                                            | Purpose                               |
+| ----------------------------------------------- | ------------------------------------- |
+| `tests/runtime/bun/bun-sql.test.js`             | Unit tests forBunSqlIdempotencyStore  |
 | `tests/runtime/bun/bun-sql-integration.test.js` | Integration tests with Hono framework |
-| `tests/runtime/bun/examples.test.js` | Example app tests |
+| `tests/runtime/bun/examples.test.js`            | Example app tests                     |
 
 ### Running Tests
 

--- a/packages/stores/bun-sql/CONTRIBUTING.md
+++ b/packages/stores/bun-sql/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## Tests
+
+Tests for this package are located in the monorepo root at `tests/runtime/bun/`, not within this package directory. This is because Bun-specific test utilities require the Bun runtime.
+
+### Test Files
+
+| File | Purpose |
+|------|---------|
+| `tests/runtime/bun/bun-sql.test.js` | Unit tests forBunSqlIdempotencyStore |
+| `tests/runtime/bun/bun-sql-integration.test.js` | Integration tests with Hono framework |
+| `tests/runtime/bun/examples.test.js` | Example app tests |
+
+### Running Tests
+
+From the monorepo root:
+
+```bash
+npm run test:bun
+```
+
+Or directly with Bun:
+
+```bash
+bun test tests/runtime/bun/
+```
+
+### Running Specific Tests
+
+```bash
+bun test tests/runtime/bun/bun-sql.test.js
+```
+
+## Development
+
+This package uses JavaScript with JSDoc for type annotations. TypeScript definitions are generated during build via `npm run build`.

--- a/packages/stores/bun-sql/package.json
+++ b/packages/stores/bun-sql/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "test": "echo 'Skipping tests - run with bun test runtime-tests/bun/' && exit 0"
+    "test": "echo 'Tests are in tests/runtime/bun/ - run: npm run test:bun' && exit 0"
   },
   "dependencies": {
     "@idempot/core": "workspace:*"


### PR DESCRIPTION
## Summary

- Adds CONTRIBUTING.md to `packages/stores/bun-sql/` pointing contributors to the actual test location at `tests/runtime/bun/`
- Fixes incorrect path in package.json test script (was `runtime-tests/bun/`, now correctly points to `tests/runtime/bun/`)

## Motivation

Tests for `bun-sql` are located in `tests/runtime/bun/` (3 test files) rather than within the package itself. This can confuse contributors who might waste time writing tests that already exist. The CONTRIBUTING.md documents the test structure and how to run tests.