### PR TITLE
refactor(postgres): use sinon fakes for unit tests

### DIFF
--- a/packages/stores/postgres/index.js
+++ b/packages/stores/postgres/index.js
@@ -12,6 +12,7 @@ const require = createRequire(import.meta.url);
  * @property {string} [connectionString] - PostgreSQL connection string
  * @property {import("pg").PoolConfig} [connection] - Connection pool options (passed to pg.Pool)
  * @property {string} [schema="public"] - Database schema for the idempotency table
+ * @property {import("pg").Pool} [pool] - Optional pre-configured pool (for testing)
  */
 
 /**
@@ -33,10 +34,14 @@ export class PostgresIdempotencyStore {
    * @param {PostgresIdempotencyStoreOptions} [options]
    */
   constructor(options = {}) {
-    const { Pool } = require("pg");
     this.schema = options.schema ?? "public";
     this.quotedSchemaIdentifier = `"${this.schema.replace(/"/g, '""')}"`;
-    this.pool = new Pool(options);
+    if (options.pool) {
+      this.pool = options.pool;
+    } else {
+      const { Pool } = require("pg");
+      this.pool = new Pool(options);
+    }
     this.initSchema();
   }
 

--- a/packages/stores/postgres/postgres.test.js
+++ b/packages/stores/postgres/postgres.test.js
@@ -1,141 +1,133 @@
-// packages/stores/postgres/postgres.test.js
 import { test } from "tap";
+import { PostgresIdempotencyStore } from "@idempot/postgres-store";
+import { createFakePgPool } from "./tests/pg-test-helpers.js";
 import { runStoreTests } from "../../core/tests/store-adapter-suite.js";
-import { createRequire } from "module";
-
-const require = createRequire(import.meta.url);
-
-const createInMemoryMockPool = () => {
-  const records = {};
-
-  return {
-    query: async (sql, params) => {
-      if (sql.includes("CREATE TABLE")) {
-        return { rows: [], rowCount: 0 };
-      }
-
-      const now = Date.now();
-
-      if (sql.includes("INSERT")) {
-        const [key, fingerprint, expiresAt] = params;
-        records[key] = {
-          key,
-          fingerprint,
-          status: "processing",
-          expires_at: expiresAt,
-          response_status: null,
-          response_headers: null,
-          response_body: null
-        };
-        return { rows: [], rowCount: 1 };
-      }
-
-      if (sql.includes("UPDATE") && sql.includes("WHERE key")) {
-        const [responseStatus, responseHeaders, responseBody, key] = params;
-        if (records[key]) {
-          records[key].status = "complete";
-          records[key].response_status = responseStatus;
-          records[key].response_headers = responseHeaders;
-          records[key].response_body = responseBody;
-          return { rows: [], rowCount: 1 };
-        }
-        return { rows: [], rowCount: 0 };
-      }
-
-      if (sql.includes("DELETE") && sql.includes("expires_at")) {
-        let deleted = 0;
-        for (const key of Object.keys(records)) {
-          if (records[key].expires_at <= now) {
-            delete records[key];
-            deleted++;
-            if (deleted >= 10) break;
-          }
-        }
-        return { rows: [], rowCount: deleted };
-      }
-
-      if (sql.includes("SELECT") && sql.includes("WHERE key")) {
-        const row = records[params[0]];
-        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
-      }
-
-      if (sql.includes("SELECT") && sql.includes("WHERE fingerprint")) {
-        const row = Object.values(records).find(
-          (r) => r.fingerprint === params[0]
-        );
-        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
-      }
-
-      return { rows: [], rowCount: 0 };
-    },
-    end: async () => {}
-  };
-};
-
-const mockPool = createInMemoryMockPool();
-
-// Cache-busting: clear require cache for pg and the store
-const pgPath = require.resolve("pg");
-delete require.cache[pgPath];
-
-const originalPool = require("pg").Pool;
-require.cache[pgPath] = {
-  id: pgPath,
-  filename: pgPath,
-  loaded: true,
-  exports: {
-    Pool: function () {
-      return mockPool;
-    }
-  }
-};
-
-const { PostgresIdempotencyStore } = await import("@idempot/postgres-store");
 
 runStoreTests({
   name: "postgres",
-  createStore: () => new PostgresIdempotencyStore()
+  createStore: () => {
+    const pool = createFakePgPool();
+    return new PostgresIdempotencyStore({ pool });
+  }
+});
+
+test("PostgresIdempotencyStore - lookup returns null for empty store", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  const result = await store.lookup("key-1", "fp-1");
+
+  t.equal(result.byKey, null, "byKey should be null");
+  t.equal(result.byFingerprint, null, "byFingerprint should be null");
+  t.end();
+});
+
+test("PostgresIdempotencyStore - lookup finds record by key", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  await store.startProcessing("key-1", "fp-1", 60000);
+
+  const result = await store.lookup("key-1", "fp-1");
+
+  t.equal(result.byKey?.key, "key-1", "should find by key");
+  t.equal(result.byKey?.status, "processing", "status should be processing");
+  t.end();
+});
+
+test("PostgresIdempotencyStore - lookup finds record by fingerprint", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  await store.startProcessing("key-1", "fp-1", 60000);
+
+  const result = await store.lookup("key-2", "fp-1");
+
+  t.equal(result.byFingerprint?.key, "key-1", "should find by fingerprint");
+  t.equal(
+    result.byFingerprint?.fingerprint,
+    "fp-1",
+    "fingerprint should match"
+  );
+  t.end();
+});
+
+test("PostgresIdempotencyStore - startProcessing creates record", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  await store.startProcessing("key-1", "fp-1", 60000);
+
+  const result = await store.lookup("key-1", "fp-1");
+
+  t.equal(result.byKey?.status, "processing", "status should be processing");
+  t.equal(result.byKey?.fingerprint, "fp-1", "fingerprint should be stored");
+  t.end();
+});
+
+test("PostgresIdempotencyStore - complete updates record", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  await store.startProcessing("key-1", "fp-1", 60000);
+
+  await store.complete("key-1", {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: '{"success":true}'
+  });
+
+  const result = await store.lookup("key-1", "fp-1");
+
+  t.equal(result.byKey?.status, "complete", "status should be complete");
+  t.equal(result.byKey?.response?.status, 200, "response status should match");
+  t.same(
+    result.byKey?.response?.headers,
+    { "Content-Type": "application/json" },
+    "headers should match"
+  );
+  t.equal(
+    result.byKey?.response?.body,
+    '{"success":true}',
+    "body should match"
+  );
+  t.end();
+});
+
+test("PostgresIdempotencyStore - complete throws on missing key", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  try {
+    await store.complete("nonexistent", {
+      status: 200,
+      headers: {},
+      body: "test"
+    });
+    t.fail("should have thrown");
+  } catch (err) {
+    t.match(
+      err.message,
+      /No record found/i,
+      "should throw error for missing key"
+    );
+  }
+  t.end();
 });
 
 test("PostgresIdempotencyStore - parseRecord handles null response_headers", async (t) => {
-  const records = {};
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
 
-  const mockPool = {
-    query: async (sql, params) => {
-      if (sql.includes("CREATE TABLE")) return { rows: [], rowCount: 0 };
-      if (sql.includes("SELECT") && sql.includes("WHERE key")) {
-        const row = records[params[0]];
-        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
-      }
-      return { rows: [], rowCount: 0 };
-    },
-    end: async () => {}
-  };
-
-  const testPath = require.resolve("pg");
-  require.cache[testPath] = {
-    id: testPath,
-    filename: testPath,
-    loaded: true,
-    exports: {
-      Pool: function () {
-        return mockPool;
-      }
-    }
-  };
-
-  const { PostgresIdempotencyStore: Store2 } =
-    await import("@idempot/postgres-store");
-  const store = new Store2();
-
-  records["test-key"] = {
+  pool.__store.set("test-key", {
     key: "test-key",
     fingerprint: "test-fp",
     status: "complete",
     response_status: 200,
     response_headers: null,
-    response_body: "test"
-  };
+    response_body: "test",
+    expires_at: Date.now() + 60000
+  });
 
   const result = await store.lookup("test-key", "test-fp");
   t.ok(result.byKey.response, "response should exist");
@@ -149,28 +141,12 @@ test("PostgresIdempotencyStore - parseRecord handles null response_headers", asy
   t.end();
 });
 
-test("PostgresIdempotencyStore - close ends pool", async (t) => {
-  let ended = false;
+test("PostgresIdempotencyStore - close calls pool.end", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
 
-  class TestPool {
-    query = async () => ({ rows: [], rowCount: 0 });
-    end = async () => {
-      ended = true;
-    };
-  }
-
-  const testPath = require.resolve("pg");
-  require.cache[testPath] = {
-    id: testPath,
-    filename: testPath,
-    loaded: true,
-    exports: { Pool: TestPool }
-  };
-
-  const { PostgresIdempotencyStore: Store2 } =
-    await import("@idempot/postgres-store");
-  const store = new Store2();
   await store.close();
-  t.ok(ended, "pool should be ended");
+
+  t.equal(pool.end.calledOnce, true, "pool.end should be called once");
   t.end();
 });

--- a/packages/stores/postgres/tests/pg-test-helpers.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.js
@@ -1,0 +1,128 @@
+import sinon from "sinon";
+
+/**
+ * Creates an in-memory store that simulates PostgreSQL table operations
+ * @returns {Map<string, any>}
+ */
+function createInMemoryStore() {
+  return new Map();
+}
+
+/**
+ * Parses SQL to extract the operation type
+ * @param {string} sql
+ * @returns {{operation: string, table: string}|null}
+ */
+function parseSql(sql) {
+  const normalized = sql.trim().toUpperCase();
+  if (normalized.startsWith("INSERT")) {
+    return { operation: "INSERT", table: "idempotency_records" };
+  }
+  if (normalized.startsWith("UPDATE")) {
+    return { operation: "UPDATE", table: "idempotency_records" };
+  }
+  if (normalized.startsWith("DELETE") && normalized.includes("EXPIRES_AT")) {
+    return { operation: "DELETE_EXPIRED", table: "idempotency_records" };
+  }
+  if (normalized.startsWith("SELECT")) {
+    return { operation: "SELECT", table: "idempotency_records" };
+  }
+  if (normalized.startsWith("CREATE")) {
+    return { operation: "CREATE", table: null };
+  }
+  return null;
+}
+
+/**
+ * Creates a fake PostgreSQL pool for unit testing using sinon fakes
+ * Uses an in-memory Map to simulate database operations
+ *
+ * @returns {object} Fake PostgreSQL pool with sinon spies
+ */
+export function createFakePgPool() {
+  const store = createInMemoryStore();
+
+  const pool = {
+    __store: store,
+
+    query: sinon.fake(async (sql, params = []) => {
+      const parsed = parseSql(sql);
+
+      if (!parsed) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (parsed.operation === "CREATE") {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (parsed.operation === "DELETE_EXPIRED") {
+        const now = params[0] || Date.now();
+        let deleted = 0;
+        for (const [key, record] of store) {
+          if (record.expires_at <= now) {
+            store.delete(key);
+            deleted++;
+          }
+        }
+        return { rows: [], rowCount: deleted };
+      }
+
+      if (parsed.operation === "INSERT") {
+        const [key, fingerprint, expiresAt] = params;
+        store.set(key, {
+          key,
+          fingerprint,
+          status: "processing",
+          expires_at: expiresAt,
+          response_status: null,
+          response_headers: null,
+          response_body: null
+        });
+        return { rows: [], rowCount: 1 };
+      }
+
+      if (parsed.operation === "UPDATE") {
+        const [responseStatus, responseHeaders, responseBody, key] = params;
+        const record = store.get(key);
+        if (record) {
+          store.set(key, {
+            ...record,
+            status: "complete",
+            response_status: responseStatus,
+            response_headers: responseHeaders,
+            response_body: responseBody
+          });
+          return { rows: [], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (parsed.operation === "SELECT") {
+        const normalizedSql = sql.toUpperCase();
+
+        if (normalizedSql.includes("WHERE KEY =")) {
+          const [key] = params;
+          const record = store.get(key);
+          return { rows: record ? [record] : [], rowCount: record ? 1 : 0 };
+        }
+
+        if (normalizedSql.includes("WHERE FINGERPRINT =")) {
+          const [fingerprint] = params;
+          for (const record of store.values()) {
+            if (record.fingerprint === fingerprint) {
+              return { rows: [record], rowCount: 1 };
+            }
+          }
+          return { rows: [], rowCount: 0 };
+        }
+      }
+
+      return { rows: [], rowCount: 0 };
+    }),
+
+    end: sinon.fake.resolves(undefined)
+  };
+
+  return pool;
+}

--- a/packages/stores/postgres/tests/pg-test-helpers.test.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.test.js
@@ -121,3 +121,22 @@ test("createFakePgPool - end is a sinon fake", async (t) => {
   t.ok(pool.end.calledOnce, "end should be tracked by sinon");
   t.end();
 });
+
+test("createFakePgPool - query returns empty result for unrecognized SQL", async (t) => {
+  const pool = createFakePgPool();
+  const result = await pool.query("DROP TABLE nonexistent");
+  t.same(result, { rows: [], rowCount: 0 }, "should return empty result for unrecognized SQL");
+  t.end();
+});
+
+test("createFakePgPool - SELECT without WHERE clause returns empty", async (t) => {
+  const pool = createFakePgPool();
+  await pool.query(
+    "INSERT INTO idempotency_records (key, fingerprint, expires_at) VALUES ($1, $2, $3)",
+    ["test-key", "test-fp", Date.now() + 60000]
+  );
+
+  const result = await pool.query("SELECT * FROM idempotency_records");
+  t.same(result, { rows: [], rowCount: 0 }, "should return empty result for SELECT without WHERE");
+  t.end();
+});

--- a/packages/stores/postgres/tests/pg-test-helpers.test.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.test.js
@@ -1,0 +1,123 @@
+import { test } from "tap";
+import { createFakePgPool } from "./pg-test-helpers.js";
+
+test("createFakePgPool - query returns empty result for CREATE statements", async (t) => {
+  const pool = createFakePgPool();
+  const result = await pool.query("CREATE TABLE test (id INT)");
+  t.same(result, { rows: [], rowCount: 0 }, "should return empty result");
+  t.end();
+});
+
+test("createFakePgPool - INSERT creates record", async (t) => {
+  const pool = createFakePgPool();
+  const result = await pool.query(
+    "INSERT INTO idempotency_records (key, fingerprint, expires_at) VALUES ($1, $2, $3)",
+    ["test-key", "test-fp", Date.now() + 60000]
+  );
+  t.equal(result.rowCount, 1, "should insert one row");
+  t.end();
+});
+
+test("createFakePgPool - SELECT by key returns inserted record", async (t) => {
+  const pool = createFakePgPool();
+  await pool.query(
+    "INSERT INTO idempotency_records (key, fingerprint, expires_at) VALUES ($1, $2, $3)",
+    ["test-key", "test-fp", Date.now() + 60000]
+  );
+
+  const result = await pool.query(
+    "SELECT * FROM idempotency_records WHERE key = $1",
+    ["test-key"]
+  );
+  t.equal(result.rows.length, 1, "should find one row");
+  t.equal(result.rows[0].key, "test-key", "should have correct key");
+  t.end();
+});
+
+test("createFakePgPool - SELECT by key returns empty for non-existent", async (t) => {
+  const pool = createFakePgPool();
+  const result = await pool.query(
+    "SELECT * FROM idempotency_records WHERE key = $1",
+    ["nonexistent"]
+  );
+  t.equal(result.rows.length, 0, "should find no rows");
+  t.end();
+});
+
+test("createFakePgPool - SELECT by fingerprint finds matching record", async (t) => {
+  const pool = createFakePgPool();
+  await pool.query(
+    "INSERT INTO idempotency_records (key, fingerprint, expires_at) VALUES ($1, $2, $3)",
+    ["key-1", "shared-fp", Date.now() + 60000]
+  );
+
+  const result = await pool.query(
+    "SELECT * FROM idempotency_records WHERE fingerprint = $1",
+    ["shared-fp"]
+  );
+  t.equal(result.rows.length, 1, "should find one row");
+  t.equal(
+    result.rows[0].fingerprint,
+    "shared-fp",
+    "should have correct fingerprint"
+  );
+  t.end();
+});
+
+test("createFakePgPool - UPDATE returns rowCount 0 for non-existent key", async (t) => {
+  const pool = createFakePgPool();
+  const result = await pool.query(
+    "UPDATE idempotency_records SET status = 'complete' WHERE key = $1",
+    ["nonexistent"]
+  );
+  t.equal(result.rowCount, 0, "should update 0 rows");
+  t.end();
+});
+
+test("createFakePgPool - DELETE removes expired records", async (t) => {
+  const pool = createFakePgPool();
+  const pastExpiry = Date.now() - 1000;
+  const futureExpiry = Date.now() + 60000;
+
+  // Manually insert with past expiry
+  pool.__store.set("expired-key", {
+    key: "expired-key",
+    fingerprint: "fp-expired",
+    status: "processing",
+    expires_at: pastExpiry,
+    response_status: null,
+    response_headers: null,
+    response_body: null
+  });
+
+  // Manually insert with future expiry
+  pool.__store.set("valid-key", {
+    key: "valid-key",
+    fingerprint: "fp-valid",
+    status: "processing",
+    expires_at: futureExpiry,
+    response_status: null,
+    response_headers: null,
+    response_body: null
+  });
+
+  await pool.query("DELETE FROM idempotency_records WHERE expires_at <= $1", [
+    Date.now()
+  ]);
+
+  t.equal(
+    pool.__store.has("expired-key"),
+    false,
+    "expired key should be deleted"
+  );
+  t.equal(pool.__store.has("valid-key"), true, "valid key should remain");
+  t.end();
+});
+
+test("createFakePgPool - end is a sinon fake", async (t) => {
+  const pool = createFakePgPool();
+  t.ok(pool.end.calledOnce === false, "end should not be called initially");
+  await pool.end();
+  t.ok(pool.end.calledOnce, "end should be tracked by sinon");
+  t.end();
+});

--- a/packages/stores/postgres/tests/pg-test-helpers.test.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.test.js
@@ -148,3 +148,32 @@ test("createFakePgPool - SELECT without WHERE clause returns empty", async (t) =
   );
   t.end();
 });
+
+test("createFakePgPool - DELETE_EXPIRED without params uses Date.now()", async (t) => {
+  const pool = createFakePgPool();
+  const pastExpiry = Date.now() - 1000;
+  pool.__store.set("expired-key", {
+    key: "expired-key",
+    fingerprint: "fp",
+    status: "processing",
+    expires_at: pastExpiry,
+    response_status: null,
+    response_headers: null,
+    response_body: null
+  });
+
+  const result = await pool.query(
+    "DELETE FROM idempotency_records WHERE expires_at <= now()"
+  );
+  t.equal(
+    result.rowCount,
+    1,
+    "should delete expired record when no params passed"
+  );
+  t.equal(
+    pool.__store.has("expired-key"),
+    false,
+    "expired key should be deleted"
+  );
+  t.end();
+});

--- a/packages/stores/postgres/tests/pg-test-helpers.test.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.test.js
@@ -125,7 +125,11 @@ test("createFakePgPool - end is a sinon fake", async (t) => {
 test("createFakePgPool - query returns empty result for unrecognized SQL", async (t) => {
   const pool = createFakePgPool();
   const result = await pool.query("DROP TABLE nonexistent");
-  t.same(result, { rows: [], rowCount: 0 }, "should return empty result for unrecognized SQL");
+  t.same(
+    result,
+    { rows: [], rowCount: 0 },
+    "should return empty result for unrecognized SQL"
+  );
   t.end();
 });
 
@@ -137,6 +141,10 @@ test("createFakePgPool - SELECT without WHERE clause returns empty", async (t) =
   );
 
   const result = await pool.query("SELECT * FROM idempotency_records");
-  t.same(result, { rows: [], rowCount: 0 }, "should return empty result for SELECT without WHERE");
+  t.same(
+    result,
+    { rows: [], rowCount: 0 },
+    "should return empty result for SELECT without WHERE"
+  );
   t.end();
 });

--- a/packages/stores/redis/tests/redis-test-helpers.test.js
+++ b/packages/stores/redis/tests/redis-test-helpers.test.js
@@ -45,3 +45,24 @@ test("createFakeRedisClient - get returns value for existing key", async (t) => 
   t.equal(result, "test-value", "should return value for existing key");
   t.end();
 });
+
+test("createFakeRedisClient - ttl returns -2 for expired key", async (t) => {
+  const client = createFakeRedisClient();
+  await client.setex("test-key", 60, "test-value");
+  const store = client.__store;
+  store.expiryTimers.set("test-key", Date.now() - 1000);
+  const ttl = await client.ttl("test-key");
+  t.equal(ttl, -2, "should return -2 for expired key");
+  t.end();
+});
+
+test("createFakeRedisClient - ttl returns -2 for expired key", async (t) => {
+  const client = createFakeRedisClient();
+  // Set a key with past expiry by manipulating internal store
+  await client.setex("test-key", 60, "test-value");
+  const store = client.__store;
+  store.expiryTimers.set("test-key", Date.now() - 1000);
+  const ttl = await client.ttl("test-key");
+  t.equal(ttl, -2, "should return -2 for expired key");
+  t.end();
+});


### PR DESCRIPTION
## Summary

- Add `pool` option to `PostgresIdempotencyStore` for dependency injection
- Create `pg-test-helpers.js` with `createFakePgPool` using sinon fakes
- Remove `require.cache` manipulation in favor of clean DI pattern
- Add tests for `pg-test-helpers.js`

This mirrors the pattern used for the Redis store tests, making them more maintainable and easier to understand.

**Before:** Tests manually manipulated Node's require cache to mock the `pg` module (50+ lines of hacks)

**After:** Tests use dependency injection with sinon-based fake pool (clean, traceable, reusable)