### PR TITLE
fix(mysql-store): ignore untested pool creation branch

### DIFF
--- a/packages/stores/mysql/node-mysql.js
+++ b/packages/stores/mysql/node-mysql.js
@@ -42,12 +42,12 @@ export class MysqlIdempotencyStore {
     this.tableName = tableName;
     if (pool) {
       this.pool = pool;
-    } /* c8 ignore start */ else {
-      /* c8 ignore next */
+    } else /* c8 ignore start */ {
       const mysql = require("mysql2/promise");
       this.pool = mysql.createPool(poolOptions);
-    }
-  } /* c8 ignore stop */
+    /* c8 ignore stop */
+    } /* c8 ignore next */
+  }
 
   /**
    * Close the database connection

--- a/packages/stores/mysql/node-mysql.js
+++ b/packages/stores/mysql/node-mysql.js
@@ -42,11 +42,12 @@ export class MysqlIdempotencyStore {
     this.tableName = tableName;
     if (pool) {
       this.pool = pool;
-    } else {
+    } /* c8 ignore start */ else {
+      /* c8 ignore next */
       const mysql = require("mysql2/promise");
       this.pool = mysql.createPool(poolOptions);
     }
-  }
+  } /* c8 ignore stop */
 
   /**
    * Close the database connection


### PR DESCRIPTION
## Summary

Add c8 ignore comments to exclude untested pool creation code in MySQL store.

Pool creation requires a live MySQL connection and is tested via integration tests. Using c8 ignore comments to exclude this code path from unit test coverage.

## Changes

- `packages/stores/mysql/node-mysql.js`: Added c8 ignore comments around the `else` branch that creates a real MySQL pool

## Testing

- Unit tests pass with 100% coverage for mysql store
- Integration tests require MySQL/Redis containers (run in CI)