### PR TITLE
fix(release): remove unnecessary build step and disable husky

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  HUSKY: 0
+
 permissions:
   contents: read
   id-token: write
@@ -26,8 +29,6 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
       - name: Verify coverage
         run: pnpm run test:verify-coverage
       - name: Release


### PR DESCRIPTION
The release workflow was failing because `pnpm build` tries to run a build script in every workspace package, but none have one defined. This is a plain JavaScript library with no build step needed.

Also disables husky in CI to prevent pre-commit hook failures when database services aren't available.