### PR TITLE
fix(release): add write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   HUSKY: 0
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Change `contents: read` to `contents: write` to fix permission error preventing semantic-release from pushing tags

## Root Cause
The release workflow failed with:
- `Permission to idempot-dev/idempot-js.git denied to github-actions[bot]`
- `Resource not accessible by integration`

This was because semantic-release needs write permission to push version tags and create releases.