### PR TITLE
fix(release): add issues write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
 
 permissions:
   contents: write
+  issues: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `issues: write` permission to release workflow to fix 403 error when semantic-release tries to create issues on failure

## Root Cause
The release workflow was failing with:
- `403 Forbidden - POST https://api.github.com/repos/idempot-dev/idempot-js/issues`
- `Resource not accessible by integration`

This was because the workflow lacked permission to create GitHub issues.