### PR TITLE
fix(release): add debug step to verify NPM_TOKEN is accessible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Debug NPM_TOKEN
+        run: |
+          echo "NPM_TOKEN exists: ${{ secrets.NPM_TOKEN != '' }}"
+        shell: bash
       - name: Release
         run: pnpm exec multi-semantic-release
         env:


### PR DESCRIPTION
## Summary
- Add debug step to release workflow to verify NPM_TOKEN secret is accessible
- This will help diagnose whether GitHub Actions can see the NPM_TOKEN environment secret

## Testing
- Check workflow output for "NPM_TOKEN exists: true" or "NPM_TOKEN exists: false"