### PR TITLE
fix(release): remove registry-url from setup-node to fix npm token auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` action to fix npm token authentication
- Add `.npmrc` with registry configuration to ensure consistent npm configuration

## Root Cause
The `registry-url` in `setup-node` creates a conflicting `.npmrc` file that conflicts with what semantic-release expects. This is a known issue per semantic-release/semantic-release#3837.

## Changes
1. Remove `registry-url: https://registry.npmjs.org` from `.github/workflows/release.yml`
2. Add `.npmrc` file with `registry=https://registry.npmjs.org/` to ensure consistent configuration