### PR TITLE
fix(release): remove environment to use repository secrets instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    environment:
-      name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- Remove `environment:` block from release workflow job to use repository secrets instead of environment secrets
- This simplifies the token configuration and removes potential environment-related issues

## Changes
- Removed `environment: name: release` from the job

## Why This Works
- Repository secrets are accessible on main branch pushes (like the release workflow)
- Fork PRs cannot access repository secrets anyway (security feature)
- Simpler configuration without environment layer

## Next Steps
- Add `NPM_TOKEN` as a repository secret at: https://github.com/idempot-dev/idempot-js/settings/secrets/actions
- Re-run the release workflow