### PR TITLE
fix(packages): add publishConfig access=public to all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap tests/"
   },

--- a/packages/frameworks/express/package.json
+++ b/packages/frameworks/express/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap express-middleware.test.js"
   },

--- a/packages/frameworks/fastify/package.json
+++ b/packages/frameworks/fastify/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap fastify-middleware.test.js"
   },

--- a/packages/frameworks/hono/package.json
+++ b/packages/frameworks/hono/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap hono-middleware.test.js"
   },

--- a/packages/stores/bun-sql/package.json
+++ b/packages/stores/bun-sql/package.json
@@ -30,6 +30,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "echo 'Tests are in tests/runtime/bun/ - run: npm run test:bun' && exit 0"
   },

--- a/packages/stores/mysql/package.json
+++ b/packages/stores/mysql/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap tests/"
   },

--- a/packages/stores/postgres/package.json
+++ b/packages/stores/postgres/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap tests/"
   },

--- a/packages/stores/redis/package.json
+++ b/packages/stores/redis/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap tests/"
   },

--- a/packages/stores/sqlite/package.json
+++ b/packages/stores/sqlite/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/idempot-dev/idempot-js"
   },
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "tap tests/"
   },


### PR DESCRIPTION
## Summary
- Add `"publishConfig": { "access": "public" }` to all 9 packages in the monorepo

## Packages Modified (9)
- @idempot/core
- @idempot/hono-middleware
- @idempot/express-middleware
- @idempot/fastify-middleware
- @idempot/sqlite-store
- @idempot/redis-store
- @idempot/postgres-store
- @idempot/mysql-store
- @idempot/bun-sql-store

## Reason
- Scoped packages (`@idempot/*`) require `--access public` flag to publish as public
- Adding publishConfig allows publishing without passing CLI flags
- Fixes 402 "You must sign up for private packages" error