### PR TITLE
fix(release): remove NPM_TOKEN, use OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,7 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Debug NPM_TOKEN
-        run: |
-          echo "NPM_TOKEN exists: ${{ secrets.NPM_TOKEN != '' }}"
-        shell: bash
       - name: Release
         run: pnpm exec multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN from release workflow environment
- Rely on OIDC Trusted Publishing for npm authentication

## Changes
- Removed `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` from env section
- Removed debug step for NPM_TOKEN

## Why This Works
- OIDC Trusted Publishing uses GitHub Actions' OIDC token to authenticate with npm
- The `id-token: write` permission (already present) enables OIDC token generation
- npm verifies the OIDC token against the trusted publisher configuration
- No npm token needed at all

## Testing
- Verify all packages have Trusted Publishing configured on npm
- Re-run release workflow after merging to test OIDC authentication