### PR TITLE
fix(packages): run npm pkg fix to correct repository.url

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/frameworks/express/package.json
+++ b/packages/frameworks/express/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/frameworks/fastify/package.json
+++ b/packages/frameworks/fastify/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/frameworks/hono/package.json
+++ b/packages/frameworks/hono/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/stores/bun-sql/package.json
+++ b/packages/stores/bun-sql/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/stores/mysql/package.json
+++ b/packages/stores/mysql/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/stores/postgres/package.json
+++ b/packages/stores/postgres/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/stores/redis/package.json
+++ b/packages/stores/redis/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/packages/stores/sqlite/package.json
+++ b/packages/stores/sqlite/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/idempot-dev/idempot-js"
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
   },
   "license": "BSD-3-Clause",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Run `npm pkg fix` on all 9 packages to correct repository.url normalization

## Changes
- All package.json files now have normalized repository URL format:
  - `"repository": { "type": "git", "url": "git+https://github.com/idempot-dev/idempot-js.git" }`

## Reason
- npm warns about repository.url during publish and auto-corrects it
- This fix prevents the warning by using the normalized format upfront