### PR TITLE
fix(release): add provenance: true to setup-node for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
+          provenance: true
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Add `provenance: true` to setup-node action to explicitly enable OIDC Trusted Publishing

## Why This Helps
- The `provenance: true` setting explicitly tells setup-node to generate OIDC tokens
- This enables npm's Trusted Publishing authentication mechanism
- Works in conjunction with `id-token: write` permission already in the workflow

## Testing
- Verify release workflow completes without ENEEDAUTH error
- Verify packages are published using OIDC authentication