### PR TITLE
fix(release): remove unsupported provenance option from setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
-          provenance: true
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Remove `provenance: true` option from setup-node action
- The `provenance` input is not supported in setup-node v6.3.0

## Why This Works
- OIDC Trusted Publishing is enabled via the `id-token: write` permission (already present in workflow)
- The provenance option was generating a warning and not actually doing anything
- Removing it allows the workflow to run without errors

## Testing
- Verify release workflow runs without the "Unexpected input" warning
- Check if OIDC authentication works (no ENEEDAUTH error)