### PR TITLE
docs: add footer with copyright, license, and ecosystem link to VitePress site

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -68,7 +68,7 @@ export default defineConfig({
     },
     socialLinks: [{ icon: "github", link: "https://github.com/idempot-dev/idempot-js" }],
     footer: {
-      message: 'Released under the <a href="https://github.com/idempot-dev/idempot-js/blob/main/LICENSE">BSD License</a>.',
+      message: 'Part of the <a href="https://idempot.dev">idempot.dev</a> ecosystem · Released under the <a href="https://github.com/idempot-dev/idempot-js/blob/main/LICENSE">BSD License</a>.',
       copyright: 'Copyright © 2026 <a href="https://github.com/mroderick">Morgan Roderick</a> and contributors'
     }
   }

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -66,6 +66,10 @@ export default defineConfig({
       "/stores/": docsSidebar,
       "/reference/": docsSidebar
     },
-    socialLinks: [{ icon: "github", link: "https://github.com/idempot-dev/idempot-js" }]
+    socialLinks: [{ icon: "github", link: "https://github.com/idempot-dev/idempot-js" }],
+    footer: {
+      message: 'Released under the <a href="https://github.com/idempot-dev/idempot-js/blob/main/LICENSE">BSD License</a>.',
+      copyright: 'Copyright © 2026 <a href="https://github.com/mroderick">Morgan Roderick</a> and contributors'
+    }
   }
 });


### PR DESCRIPTION
## Summary

Adds a footer to the VitePress documentation site with:
- Copyright notice for Morgan Roderick and contributors (2026)
- BSD License link pointing to the LICENSE file
- Link to idempot.dev ecosystem

## Changes

- Updated `docs/.vitepress/config.mjs` to add `footer` configuration to `themeConfig`
- Footer displays: "Part of the [idempot.dev](https://idempot.dev) ecosystem · Released under the [BSD License](https://github.com/idempot-dev/idempot-js/blob/main/LICENSE)."
- Copyright: "Copyright © 2026 [Morgan Roderick](https://github.com/mroderick) and contributors"

## Testing

- VitePress dev server starts successfully with the new configuration
- All existing tests pass

## Screenshots

Footer will appear on all documentation pages, providing users with:
1. Clear indication this is part of the idempot.dev ecosystem
2. Easy access to license information
3. Copyright attribution