### PR TITLE
docs(agents): add pnpm + git worktrees guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,33 @@ Run `pnpm run test:verify-coverage` before committing. When trying to learn whic
 
 **pnpm is the required package manager for this project.** Always use `pnpm` instead of `npm` or `yarn`.
 
+## Git Worktrees + pnpm
+
+**Why worktrees:** Isolated workspaces for parallel agent work without interference.
+
+**Global virtual store** (enabled in `pnpm-workspace.yaml`):
+
+- Each worktree's `node_modules` contains symlinks to a shared package store
+- First `pnpm install` downloads packages; subsequent worktrees are nearly instant
+- Minimal per-worktree disk overhead
+
+**Worktree creation workflow:**
+
+1. Create worktree: `git worktree add .worktrees/<branch-name> -b <branch-name>`
+2. `cd .worktrees/<branch-name>`
+3. Run `pnpm install` (creates symlinks to shared store)
+4. Verify baseline: `pnpm test`
+
+**Critical:** Never share `node_modules` between worktrees. Each needs its own symlink tree.
+
+### ESM Considerations
+
+This project uses ESM (`"type": "module"`). The global virtual store relies on `NODE_PATH` for hoisted dependencies:
+
+- Most packages work transparently
+- If you see ESM import errors, check if the package uses undeclared dependencies
+- Solutions: add to `packageExtensions` in pnpm-workspace.yaml, or use `@pnpm/plugin-esm-node-path`
+
 ## Spec Compliance
 
 This library implements the [IETF Idempotency-Key Header draft specification](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - "packages/stores/*"
 allowBuilds:
   better-sqlite3: true
+
+enableGlobalVirtualStore: true


### PR DESCRIPTION
## Summary

- Adds `enableGlobalVirtualStore: true` to `pnpm-workspace.yaml` for efficient multi-agent development
- Documents the correct worktree creation workflow for pnpm projects
- Includes ESM compatibility considerations when using the global virtual store

## Context

Based on the [pnpm git worktrees documentation](https://pnpm.io/11.x/git-worktrees), enabling the global virtual store allows each worktree's `node_modules` to contain only symlinks to a shared package store. This makes creating new worktrees nearly instant after the first install, with minimal disk overhead per worktree.

This is particularly valuable for AI coding agents that need isolated workspaces for parallel work.