### PR TITLE
fix(ci): upgrade Node.js to 24 fornpm 11.6.2+ trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24
       - name: Enable pnpm
         run: corepack enable
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The release workflow was failing with `ENEEDAUTH` error when trying to publish to npm. This is a misleading error message from npm - the actual issue was npm version compatibility with trusted publishing (OIDC).

## Solution

1. **Upgrade Node.js to 24** - Node.js 24 bundles npm >= 11.6.2 which has better trusted publishing support

I found the solution in this issue: https://github.com/npm/cli/issues/9088#issuecomment-4030343740

## Changes

### `.github/workflows/release.yml`
- Node.js 22 → 24

### `.github/workflows/ci.yml`
- Lint job: Node.js 22 → 24
- Commitlint job: Node.js 22 → 24
- Deno job: Node.js 22 → 24
- Test matrix remains at `["22", "24"]` for compatibility testing

## Context

- Node.js 24 is the current LTS
- npm 11.6.2+ shipped with Node.js 24 includes improved trusted publishing support
- This fixes the npmjs/cli#9088 issue where trusted publishing failures report misleading ENEEDAUTH errors

## Testing

- CI will run with both Node.js 22 and 24 (test matrix)
-Release workflow will use Node.js 24 (npm 11.9.0)