### PR TITLE
chore(config): configure semantic-release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,23 @@
 export default {
   branches: ["main"],
   plugins: [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "conventionalcommits",
+        releaseRules: [
+          { type: "docs", release: false },
+          { type: "style", release: false },
+          { type: "refactor", release: false },
+          { type: "test", release: false },
+          { type: "build", release: false },
+          { type: "ci", release: false },
+          { type: "chore", release: false },
+          { type: "fix", scope: "config", release: false },
+          { type: "feat", scope: "config", release: false }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
     "@semantic-release/github"


### PR DESCRIPTION
- Configure semantic-release to ignore docs/style/config changes from triggering releases
- Prevents unnecessary patch releases for documentation-only changes