### PR TITLE
fix(ci): add pull-requests write permission for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ env:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Problem

The release workflow was failing with a permission error:
```
[5:19:27 PM] [@idempot/sqlite-store] [@semantic-release/github] › ✘  Not allowed to add a comment to the issue/PR #55.
```

The `@semantic-release/github` plugin's `success` step tries to comment on merged PRs to notify which commits were included in a release, but the `GITHUB_TOKEN` lacked the necessary permission.

## Solution

Add `pull-requests: write` permission to the release workflow permissions block.

## Changes

### `.github/workflows/release.yml`
- Add `pull-requests: write` permission

## Context

The workflow already had:
- `contents: write` - for creating tags and releases
- `issues: write` - for commenting on issues
- `id-token: write` - for OIDC/trusted publishing

But was missing `pull-requests: write` which is required to comment on pull requests (including merged ones).

## Testing

This will be tested when the next release is triggered by pushing to main.