### PR TITLE
feat(docs): add sitemap generation for SEO

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -50,6 +50,9 @@ export default withMermaid(
   defineConfig({
     title: "idempot-js",
     description: "Idempotency middlewares for Node.js",
+    sitemap: {
+      hostname: "https://js.idempot.dev"
+    },
     markdown: {
       mermaid: true
     },


### PR DESCRIPTION
## Summary
- Add VitePress sitemap configuration for automatic sitemap.xml generation
- Sitemap will be generated at build time with hostname `https://js.idempot.dev`
- Enables search engines to discover and index all documentation pages

## Changes
- Added `sitemap.hostname` to VitePress config pointing to production site
- Build now generates `sitemap.xml` with 22 pages from learn/guide/frameworks/stores/reference sections

## Testing
- Verified build generates sitemap: `pnpm docs:build` → `docs/.vitepress/dist/sitemap.xml`
- Sitemap containsall expected pages with correct URLs