### PR TITLE
docs: add changelog link to GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ app.post("/orders", idempotency({ store }), async (c) => {
 
 See the `examples/` directory for complete examples.
 
+## Changelog
+
+See [GitHub Releases](https://github.com/idempot-dev/idempot-js/releases) for the changelog.
+
 ## License
 
 BSD-3


### PR DESCRIPTION
Adds a link to GitHub Releases in the README so users can easily find the changelog. The releases are already populated by semantic-release with descriptions generated from conventional commits.