### PR TITLE
feat(dev): conditionally skip tests in pre-commit for non-code changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,12 @@
+#!/bin/sh
+
+# Always run lint-staged (formatting and linting)
 pnpm exec lint-staged -q
-npm run test:verify-coverage-min
+
+# Get list of staged files (Added, Changed, Modified - not deleted)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+
+# Run tests only when source files, tests, or relevant configs change
+if echo "$STAGED" | grep -qE '\.(js|ts|mjs|cjs)$|\.feature$|package\.json$|pnpm-workspace\.yaml$|tests/runtime/deno/deno\.json$'; then
+    npm run test:verify-coverage-min
+fi


### PR DESCRIPTION
## Summary

Optimizes the pre-commit hook to skip the full test suite when only documentation or non-code files are changed.

## Problem

Every commit ran `npm run test:verify-coverage-min`, which takes ~30-60 seconds even for trivial documentation changes like updating a README.

## Solution

The pre-commit hook now checks staged files and only runs tests when relevant files change.

### Files that trigger tests:
- `*.js`, `*.ts`, `*.mjs`, `*.cjs` - Source code and tests
- `*.feature` - Cucumber spec tests  
- `package.json` - Package configs (validated by monorepo tests)
- `pnpm-workspace.yaml` - Workspace config (validated by monorepo tests)
- `tests/runtime/deno/deno.json` - Deno import maps

### Files that skip tests:
- `*.md` - Documentation (37 files)
- `*.yml`, `*.yaml` - CI configs (except pnpm-workspace.yaml)
- `jsr.json`, `.commitlintrc.json`, etc. - Tool configs
- `pnpm-lock.yaml`, `deno.lock` - Lock files
- Shell scripts, LICENSE files, etc.

## Testing

- [x] Shell script syntax verified (`sh -n`)
- [x] Pattern matching tested with various file types
- [x] Full test suite passes on this branch
- [x] Commit with only markdown changes skips tests
- [x] Commit with JS changes runs tests

## Backwards Compatibility

- lint-staged always runs (formatting/linting)
- Tests still run by default for any code changes
- Mixed changes (code + docs) run tests (safe default)