### PR TITLE
docs: update tagline to "Once is enough."

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: Production-ready idempotency middleware for Express, Fastify, and H
 hero:
   name: idempot-js
   text: Idempotency for Node.js, Bun, and Deno
-  tagline: Middleware for Express, Fastify, and Hono with pluggable storage backends
+  tagline: Once is enough.
   actions:
     - theme: brand
       text: Learn ↗


### PR DESCRIPTION
Update the docs homepage tagline from the descriptive "Middleware for Express, Fastify, and Hono with pluggable storage backends" to the concise, memorable "Once is enough." for brand consistency across idempot.dev projects.