### PR TITLE
feat: document available storage backends in framework readmes

### DIFF
--- a/packages/frameworks/express/README.md
+++ b/packages/frameworks/express/README.md
@@ -5,8 +5,18 @@ Express middleware for idempotency.
 ## Installation
 
 ```bash
-npm install @idempot/express-middleware @idempot/sqlite-store
+npm install @idempot/express-middleware
 ```
+
+### Available Stores
+
+Choose a storage backend that fits your infrastructure:
+
+- `@idempot/sqlite-store` - great for development and single-node deployments
+- `@idempot/redis-store`
+- `@idempot/postgres-store`
+- `@idempot/mysql-store`
+- `@idempot/bun-sql-store` - Bun runtime
 
 ## Usage
 

--- a/packages/frameworks/fastify/README.md
+++ b/packages/frameworks/fastify/README.md
@@ -5,8 +5,18 @@ Fastify middleware for idempotency.
 ## Installation
 
 ```bash
-npm install @idempot/fastify-middleware @idempot/sqlite-store
+npm install @idempot/fastify-middleware
 ```
+
+### Available Stores
+
+Choose a storage backend that fits your infrastructure:
+
+- `@idempot/sqlite-store` - great for development and single-node deployments
+- `@idempot/redis-store`
+- `@idempot/postgres-store`
+- `@idempot/mysql-store`
+- `@idempot/bun-sql-store` - Bun runtime
 
 ## Usage
 

--- a/packages/frameworks/hono/README.md
+++ b/packages/frameworks/hono/README.md
@@ -5,8 +5,18 @@ Hono middleware for idempotency.
 ## Installation
 
 ```bash
-npm install @idempot/hono-middleware @idempot/sqlite-store
+npm install @idempot/hono-middleware
 ```
+
+### Available Stores
+
+Choose a storage backend that fits your infrastructure:
+
+- `@idempot/sqlite-store` - great for development and single-node deployments
+- `@idempot/redis-store`
+- `@idempot/postgres-store`
+- `@idempot/mysql-store`
+- `@idempot/bun-sql-store` - Bun runtime
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Updated the README files for all three framework packages (Express, Fastify, Hono) to list all available storage backend options.

## Changes

Added "Available Stores" section to:
- `@idempot/express-middleware` README
- `@idempot/fastify-middleware` README
- `@idempot/hono-middleware` README

### Listed Stores

- `@idempot/sqlite-store` - great for development and single-node deployments
- `@idempot/redis-store`
- `@idempot/postgres-store`
- `@idempot/mysql-store`
- `@idempot/bun-sql-store` - Bun runtime

This helps users understand they have multiple storage options beyond the SQLite example shown in the quick start.