### PR TITLE
docs: add shared middleware example and guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -10,7 +10,8 @@ const docsSidebar = [
     items: [
       { text: "Overview", link: "/guide/" },
       { text: "Installation", link: "/guide/installation" },
-      { text: "Configuration", link: "/guide/configuration" }
+      { text: "Configuration", link: "/guide/configuration" },
+      { text: "Sharing Middleware", link: "/guide/shared-middleware" }
     ]
   },
   {

--- a/docs/guide/shared-middleware.md
+++ b/docs/guide/shared-middleware.md
@@ -1,0 +1,161 @@
+---
+title: Sharing Middleware Across Endpoints - idempot-js
+description: Learn how to reuse a single idempotency middleware instance across multiple API endpoints for consistent configuration and shared circuit breaker state.
+---
+
+# Sharing Middleware Across Endpoints
+
+You can reuse the same idempotency middleware instance across multiple endpoints. This approach provides consistent configuration and shared circuit breaker monitoring across your API.
+
+## Why Share Middleware?
+
+**Consistent Configuration**: All endpoints use the same TTL, key validation, and resilience settings.
+
+**Shared Circuit Breaker**: Monitor storage health from a single state object instead of multiple instances.
+
+**Performance**: Create the middleware once, use it everywhere.
+
+## How It Works
+
+The middleware uses request fingerprints to distinguish operations. The fingerprint includes:
+
+- Request body content
+- HTTP method
+- Excluded fields (if configured)
+
+Each endpoint naturally creates different fingerprints because they have different request bodies and paths. This means:
+
+- Same idempotency key on `/orders` → one operation
+- Same idempotency key on `/payments` → different operation
+- Same idempotency key on same endpoint with same body → duplicate detected
+
+## Basic Pattern
+
+Create the middleware once and apply it to multiple routes:
+
+```javascript
+import express from "express";
+import { idempotency } from "@idempot/express-middleware";
+import { PostgresIdempotencyStore } from "@idempot/postgres-store";
+
+const app = express();
+const store = new PostgresIdempotencyStore({
+  connectionString: process.env.DATABASE_URL
+});
+
+// Create ONE middleware instance
+const idempotencyMiddleware = idempotency({
+  store,
+  required: true,
+  ttlMs: 24 * 60 * 60 * 1000 // 24 hours
+});
+
+// Apply to multiple endpoints
+app.post("/orders", idempotencyMiddleware, createOrderHandler);
+app.post("/payments", idempotencyMiddleware, processPaymentHandler);
+app.post("/transfers", idempotencyMiddleware, createTransferHandler);
+
+// Monitor circuit breaker from the shared instance
+app.get("/health", (req, res) => {
+  res.json({
+    status: "healthy",
+    circuit: idempotencyMiddleware.circuit.status
+  });
+});
+```
+
+## Circuit Breaker State
+
+When you share a middleware instance, the circuit breaker state is shared across all endpoints:
+
+```javascript
+const middleware = idempotency({ store });
+
+// All endpoints share this circuit state
+app.post("/orders", middleware, handler);
+app.post("/payments", middleware, handler);
+
+// Check if storage is healthy
+console.log(middleware.circuit.status); // 'closed', 'open', or 'half-open'
+```
+
+This is usually what you want—if PostgreSQL goes down, you want all endpoints to know about it and respond with 503 Service Unavailable.
+
+## When to Create Separate Instances
+
+Create separate middleware instances when endpoints need different configurations:
+
+```javascript
+// Short TTL for webhooks (retries happen quickly)
+const webhookIdempotency = idempotency({
+  store,
+  ttlMs: 60 * 60 * 1000 // 1 hour
+});
+
+// Long TTL for financial operations
+const paymentIdempotency = idempotency({
+  store,
+  ttlMs: 7 * 24 * 60 * 60 * 1000 // 7 days
+});
+
+app.post("/webhooks", webhookIdempotency, handleWebhook);
+app.post("/payments", paymentIdempotency, processPayment);
+```
+
+## Complete Example
+
+See [`examples/express-postgres-multi-endpoint.js`](https://github.com/idempot-dev/idempot-js/blob/main/examples/express-postgres-multi-endpoint.js) for a runnable Express application that demonstrates:
+
+- Single middleware instance protecting `/orders`, `/payments`, and `/transfers`
+- PostgreSQL storage with automatic table creation
+- Circuit breaker monitoring via `/health` endpoint
+- Curl commands to test idempotency across different endpoints
+
+Run it with:
+
+```bash
+# Set up PostgreSQL (creates table automatically)
+export DATABASE_URL="postgres://user:pass@localhost:5432/mydb"
+
+# Run the example
+node examples/express-postgres-multi-endpoint.js
+```
+
+## Framework-Specific Notes
+
+### Express
+
+Express middleware can be reused directly:
+
+```javascript
+const middleware = idempotency({ store });
+
+app.post("/a", middleware, handlerA);
+app.post("/b", middleware, handlerB);
+```
+
+### Fastify
+
+Fastify's plugin system works with shared middleware:
+
+```javascript
+const middleware = idempotency({ store });
+
+fastify.post("/a", { preHandler: middleware }, handlerA);
+fastify.post("/b", { preHandler: middleware }, handlerB);
+```
+
+### Hono
+
+Hono middleware can be shared the same way:
+
+```javascript
+const middleware = idempotency({ store });
+
+app.post("/a", middleware, handlerA);
+app.post("/b", middleware, handlerB);
+```
+
+## Key Takeaway
+
+Sharing middleware is safe and recommended when endpoints need the same idempotency behavior. The request fingerprinting ensures proper isolation between endpoints while giving you centralized monitoring and configuration.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,14 +29,15 @@ All examples follow a similar pattern. To run any example:
 
 ### Node.js Server Examples
 
-| File               | Storage             | Description                                                                                 |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------------------- |
-| `basic-app.js`     | SQLite (in-memory)  | Basic Node.js server with SQLite, demonstrating optional/required keys and field exclusions |
-| `sqlite-app.js`    | SQLite (file-based) | Node.js server with persistent SQLite storage                                               |
-| `bun-basic-app.js` | SQLite (in-memory)  | Bun runtime with SQLite storage (in-memory)                                                 |
-| `bun-sql-app.js`   | SQLite/PG/MySQL     | Bun runtime with configurable SQL storage (SQLite, PostgreSQL, MySQL via connection string) |
-| `redis-app.js`     | Redis               | Node.js server with Redis persistence (requires Redis server)                               |
-| `postgres-app.js`  | PostgreSQL          | Node.js server with PostgreSQL persistence                                                  |
+| File                                 | Storage             | Description                                                                                 |
+| ------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------- |
+| `basic-app.js`                       | SQLite (in-memory)  | Basic Node.js server with SQLite, demonstrating optional/required keys and field exclusions |
+| `sqlite-app.js`                      | SQLite (file-based) | Node.js server with persistent SQLite storage                                               |
+| `bun-basic-app.js`                   | SQLite (in-memory)  | Bun runtime with SQLite storage (in-memory)                                                 |
+| `bun-sql-app.js`                     | SQLite/PG/MySQL     | Bun runtime with configurable SQL storage (SQLite, PostgreSQL, MySQL via connection string) |
+| `redis-app.js`                       | Redis               | Node.js server with Redis persistence (requires Redis server)                               |
+| `postgres-app.js`                    | PostgreSQL          | Node.js server with PostgreSQL persistence                                                  |
+| `express-postgres-multi-endpoint.js` | PostgreSQL          | Express with shared middleware instance across multiple endpoints                           |
 
 ### Deno Examples
 
@@ -140,6 +141,33 @@ psql -d your_database -f examples/postgres-setup.sh
 ```
 
 ## Feature Demonstrations
+
+### Sharing Middleware Across Endpoints
+
+You can reuse the same middleware instance across multiple endpoints. This provides consistent configuration and shared circuit breaker monitoring:
+
+```javascript
+import express from "express";
+import { idempotency } from "@idempot/express-middleware";
+
+const app = express();
+const store = new PostgresIdempotencyStore({
+  connectionString: process.env.DATABASE_URL
+});
+
+// Create ONE middleware instance
+const sharedMiddleware = idempotency({ store, required: true });
+
+// Use it on multiple endpoints
+app.post("/orders", sharedMiddleware, createOrder);
+app.post("/payments", sharedMiddleware, processPayment);
+app.post("/transfers", sharedMiddleware, createTransfer);
+
+// Circuit breaker state is shared
+console.log(sharedMiddleware.circuit.status); // 'closed', 'open', or 'half-open'
+```
+
+See [`express-postgres-multi-endpoint.js`](./express-postgres-multi-endpoint.js) for a complete example.
 
 ### Optional vs Required Idempotency Keys
 

--- a/examples/express-postgres-multi-endpoint.js
+++ b/examples/express-postgres-multi-endpoint.js
@@ -1,0 +1,139 @@
+import express from "express";
+import { idempotency } from "../packages/frameworks/express/index.js";
+import { PostgresIdempotencyStore } from "../packages/stores/postgres/index.js";
+import { ulid } from "ulid";
+
+// Create a single Express app
+const app = express();
+
+// Parse JSON request bodies
+app.use(express.json());
+
+// Create a PostgreSQL-backed store
+// The table will be created automatically on first use
+const store = new PostgresIdempotencyStore({
+  connectionString: process.env.DATABASE_URL
+});
+
+// Create ONE middleware instance to share across endpoints
+// This demonstrates that the same middleware can protect multiple routes
+const sharedIdempotency = idempotency({
+  store,
+  required: true // All endpoints require idempotency-key header
+});
+
+// Each endpoint uses the SAME middleware instance
+// This works because the request fingerprint includes the URL path,
+// so /orders and /payments with the same idempotency-key are treated as
+// different operations
+
+// Orders endpoint - uses shared middleware
+app.post("/orders", sharedIdempotency, async (req, res) => {
+  const orderId = ulid();
+
+  console.log(`Creating order: ${orderId}`);
+
+  // Simulate order processing delay
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  res.status(201).json({
+    id: orderId,
+    type: "order",
+    status: "created",
+    ...req.body
+  });
+});
+
+// Payments endpoint - uses the SAME shared middleware
+app.post("/payments", sharedIdempotency, async (req, res) => {
+  const paymentId = ulid();
+
+  console.log(`Processing payment: ${paymentId}`);
+
+  // Simulate payment processing
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  res.status(200).json({
+    id: paymentId,
+    type: "payment",
+    status: "completed",
+    ...req.body
+  });
+});
+
+// Transfers endpoint - also uses the SAME shared middleware
+app.post("/transfers", sharedIdempotency, async (req, res) => {
+  const transferId = ulid();
+
+  console.log(`Processing transfer: ${transferId}`);
+
+  // Simulate transfer processing
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  res.status(201).json({
+    id: transferId,
+    type: "transfer",
+    status: "completed",
+    ...req.body
+  });
+});
+
+// Health check (no idempotency required)
+app.get("/health", (req, res) => {
+  res.json({
+    status: "healthy",
+    circuit: sharedIdempotency.circuit.status
+  });
+});
+
+// Start server
+const PORT = process.env.PORT || 3000;
+const server = app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+  console.log("");
+  console.log("This example demonstrates using the SAME middleware instance");
+  console.log("across multiple endpoints with PostgreSQL storage.");
+  console.log("");
+  console.log("Key insight: Each endpoint is isolated because the request");
+  console.log("fingerprint includes the URL path. Same idempotency-key on");
+  console.log("different endpoints = different operations.");
+  console.log("");
+  console.log("Circuit breaker state is shared (check /health).");
+  console.log("");
+  console.log("Try these requests:");
+  console.log("");
+  console.log("# 1. Create an order");
+  console.log(
+    `curl -X POST http://localhost:${PORT}/orders -H "Content-Type: application/json" -H "idempotency-key: my-key-123" -d '{"item": "widget", "quantity": 5}'`
+  );
+  console.log("");
+  console.log("# 2. Replay the SAME order (returns cached response)");
+  console.log(
+    `curl -X POST http://localhost:${PORT}/orders -H "Content-Type: application/json" -H "idempotency-key: my-key-123" -d '{"item": "widget", "quantity": 5}'`
+  );
+  console.log("");
+  console.log(
+    "# 3. Create a PAYMENT with the SAME key (different endpoint = new operation)"
+  );
+  console.log(
+    `curl -X POST http://localhost:${PORT}/payments -H "Content-Type: application/json" -H "idempotency-key: my-key-123" -d '{"amount": 100, "currency": "USD"}'`
+  );
+  console.log("");
+  console.log("# 4. Create a TRANSFER (also uses same shared middleware)");
+  console.log(
+    `curl -X POST http://localhost:${PORT}/transfers -H "Content-Type: application/json" -H "idempotency-key: transfer-456" -d '{"from": "account-1", "to": "account-2", "amount": 50}'`
+  );
+  console.log("");
+  console.log("# 5. Check circuit breaker status");
+  console.log(`curl http://localhost:${PORT}/health`);
+  console.log("");
+});
+
+// Graceful shutdown
+process.on("SIGINT", async () => {
+  console.log("\nShutting down...");
+  await store.close();
+  server.close(() => {
+    process.exit(0);
+  });
+});


### PR DESCRIPTION
This PR adds documentation and a runnable example demonstrating how to reuse the same idempotency middleware instance across multiple endpoints.

## Changes

- **New example**: `examples/express-postgres-multi-endpoint.js` - Shows Express + PostgreSQL with shared middleware protecting /orders, /payments, and /transfers endpoints
- **New documentation**: `docs/guide/shared-middleware.md` - Guide explaining the pattern, benefits, and when to use separate instances
- **Updated examples README**: Added new entry to the examples table and feature demonstration section
- **Updated VitePress config**: Added new guide page to sidebar navigation

## Key Points

The same middleware instance can be safely shared across endpoints because:
- Request fingerprinting includes URL path, so different endpoints are isolated
- Circuit breaker state is shared (useful for monitoring)
- Configuration is consistent across all protected endpoints

## Testing

- All tests pass (100% coverage maintained)
- Docs build successfully
- Example file syntax validated