### PR TITLE
feat: RFC 9457 compliance with agent-friendly error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,75 @@ This approach simplifies maintenance while giving TypeScript users an excellent 
 
 Duplicate requests return cached responses with `x-idempotent-replayed: true`.
 
+## Error Responses (RFC 9457)
+
+Error responses follow [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (Problem Details for HTTP APIs) and include:
+
+- `type` - URI identifying the problem type
+- `title` - Short human-readable summary
+- `detail` - Detailed explanation
+- `status` - HTTP status code
+- `instance` - Unique identifier for this error occurrence
+- `retryable` - Whether retrying might succeed
+- `idempotency_key` - The idempotency key from the request (when applicable)
+
+### Content Negotiation
+
+The middleware supports content negotiation via the `Accept` header:
+
+**Default (application/problem+json):**
+
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Content-Type: application/json" \
+  -d '{"item": "widget"}'
+```
+
+Response:
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1",
+  "title": "Idempotency-Key is missing",
+  "detail": "This operation is idempotent and it requires correct usage of Idempotency Key.",
+  "status": 400,
+  "instance": "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+  "retryable": false
+}
+```
+
+**Markdown format (for AI agents):**
+
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Accept: text/markdown" \
+  -H "Content-Type: application/json" \
+  -d '{"item": "widget"}'
+```
+
+Response:
+
+```markdown
+---
+type: "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1"
+status: 400
+instance: "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
+retryable: false
+---
+
+# Idempotency-Key is missing
+
+## What Happened
+
+This operation is idempotent and it requires correct usage of Idempotency Key.
+
+## What You Should Do
+
+**Correct the issue.** This error requires changes to your request. Do not retry with the same idempotency key until the issue is resolved.
+```
+
+The markdown format includes YAML frontmatter with all error fields and human-readable guidance for AI agents.
+
 ## Quick Start
 
 ```bash

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,7 +34,10 @@ const docsSidebar = [
   },
   {
     text: "Reference",
-    items: [{ text: "Core", link: "/reference/core" }]
+    items: [
+      { text: "Core", link: "/reference/core" },
+      { text: "Error Reference", link: "/reference/errors" }
+    ]
   }
 ];
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,270 @@
+---
+title: Error Reference - idempot-js
+description: Complete reference for RFC 9457 compliant error responses including all error types, field descriptions, and examples.
+---
+
+# Error Reference
+
+idempot-js returns [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) compliant error responses for all error conditions. This standard format makes errors machine-readable and provides clear guidance for both human developers and AI agents.
+
+## Response Format
+
+All error responses include these fields:
+
+| Field             | Type      | Description                                            |
+| ----------------- | --------- | ------------------------------------------------------ |
+| `type`            | `string`  | URI identifying the error type                         |
+| `title`           | `string`  | Short, human-readable summary                          |
+| `detail`          | `string`  | Detailed explanation of what happened                  |
+| `status`          | `number`  | HTTP status code                                       |
+| `instance`        | `string`  | Unique identifier for this error occurrence (UUID)     |
+| `retryable`       | `boolean` | Whether retrying the request might succeed             |
+| `idempotency_key` | `string`  | The idempotency key from the request (when applicable) |
+
+### Instance ID
+
+The `instance` field contains a unique identifier in the format `urn:uuid:<uuid>`. Use this when contacting support or debugging issues:
+
+```json
+{
+  "instance": "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Retryable Flag
+
+The `retryable` field indicates whether the error might be transient:
+
+- `retryable: true` - Wait and retry the request. Errors like concurrent processing (409) or store unavailability (503) may resolve on retry.
+- `retryable: false` - Correct the issue before retrying. Errors like missing keys (400) or key reuse (422) require client-side changes.
+
+## Error Types
+
+### 400 Bad Request
+
+**Missing Idempotency-Key**
+
+Returned when the `Idempotency-Key` header is required but not provided.
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1",
+  "title": "Idempotency-Key is missing",
+  "detail": "This operation is idempotent and it requires correct usage of Idempotency Key.",
+  "status": 400,
+  "instance": "urn:uuid:abc123...",
+  "retryable": false
+}
+```
+
+**Invalid Key Format**
+
+Returned when the key fails validation (too short, too long, or contains commas).
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1",
+  "title": "Invalid Idempotency-Key",
+  "detail": "Idempotency key must be between 21 and 255 characters",
+  "status": 400,
+  "instance": "urn:uuid:def456...",
+  "retryable": false,
+  "idempotency_key": "short"
+}
+```
+
+**How to fix:**
+
+- Generate keys using any of these libraries (21+ characters):
+  - **UUID v4** - Universally unique identifier (36 characters)
+  - **nanoid** - 21 characters by default, collision-resistant
+  - **ULID** - Sortable, lexicographically ordered identifiers
+- Ensure keys don't contain commas
+- Keys must be between 21-255 characters
+
+### 409 Conflict
+
+**Concurrent Request Processing**
+
+Returned when a request with the same idempotency key is already being processed.
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.6",
+  "title": "A request is outstanding for this Idempotency-Key",
+  "detail": "A request with this idempotency key is already being processed",
+  "status": 409,
+  "instance": "urn:uuid:ghi789...",
+  "retryable": true,
+  "idempotency_key": "my-key-123"
+}
+```
+
+**How to fix:**
+
+- Wait briefly and retry with the same idempotency key
+- The first request will complete and be cached
+- Subsequent retries will return the cached response
+
+**Fingerprint Conflict**
+
+Returned when a different idempotency key was used for the same request payload.
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.2",
+  "title": "Fingerprint conflict",
+  "detail": "This request was already processed with a different idempotency key",
+  "status": 409,
+  "instance": "urn:uuid:jkl012...",
+  "retryable": false,
+  "idempotency_key": "different-key"
+}
+```
+
+**How to fix:**
+
+- Use the same idempotency key for identical requests
+- This prevents accidental duplicate processing
+- If intentional, the response shows the original was already handled
+
+### 422 Unprocessable Content
+
+**Key Reuse with Different Payload**
+
+Returned when an idempotency key is reused with a different request body.
+
+```json
+{
+  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.2",
+  "title": "Idempotency-Key is already used",
+  "detail": "Idempotency key reused with different request payload",
+  "status": 422,
+  "instance": "urn:uuid:mno345...",
+  "retryable": false,
+  "idempotency_key": "reused-key"
+}
+```
+
+**How to fix:**
+
+- Generate a new unique idempotency key for different requests
+- Idempotency keys must uniquely identify both the operation AND the payload
+- This prevents accidental reuse of keys across different operations
+
+### 503 Service Unavailable
+
+**Store Unavailable**
+
+Returned when the idempotency store is temporarily unavailable (circuit breaker open or connection failed).
+
+```json
+{
+  "type": "https://js.idempot.dev/problems#store-unavailable",
+  "title": "Service temporarily unavailable",
+  "detail": "The idempotency store is temporarily unavailable. Please retry.",
+  "status": 503,
+  "instance": "urn:uuid:pqr678...",
+  "retryable": true
+}
+```
+
+**How to fix:**
+
+- Wait and retry the request
+- The circuit breaker will test recovery automatically
+- Check store health (database connections, Redis availability, etc.)
+
+## Content Negotiation
+
+Request different response formats using the `Accept` header:
+
+### JSON Format
+
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"item": "widget"}'
+```
+
+Returns `application/json` content type with the same body structure.
+
+### Problem Details Format (Default)
+
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Accept: application/problem+json" \
+  -H "Content-Type: application/json" \
+  -d '{"item": "widget"}'
+```
+
+Returns `application/problem+json` content type (RFC 9457 standard).
+
+### Markdown Format (AI-Friendly)
+
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Accept: text/markdown" \
+  -H "Content-Type: application/json" \
+  -d '{"item": "widget"}'
+```
+
+Returns `text/markdown` with YAML frontmatter containing all fields and human-readable guidance. Ideal for:
+
+- AI agents parsing error responses
+- Log analysis tools
+- Documentation generation
+
+## Type URIs
+
+Error `type` URIs follow this pattern:
+
+- **Spec errors:** `https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-X.Y`
+- **Infrastructure errors:** `https://js.idempot.dev/problems#<error-name>`
+
+The spec errors reference the IETF draft document. Infrastructure errors use the project's own URI space for implementation-specific issues.
+
+## Handling Errors
+
+```javascript
+const response = await fetch("/orders", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Idempotency-Key": key
+  },
+  body: JSON.stringify(data)
+});
+
+if (!response.ok) {
+  const error = await response.json();
+
+  if (error.retryable) {
+    // Wait and retry
+    await delay(1000);
+    return retryRequest();
+  }
+
+  // Log for debugging
+  console.error(`Error ${error.status}: ${error.title}`, {
+    instance: error.instance,
+    detail: error.detail
+  });
+
+  throw new Error(error.detail);
+}
+```
+
+## Debugging with Instance IDs
+
+When reporting issues or debugging:
+
+1. Capture the `instance` field from the error response
+2. Include it in support requests
+3. Use it to correlate logs across distributed systems
+4. The UUID format ensures global uniqueness
+
+Example support request:
+
+> "We're seeing 409 errors for key `order-123`. Instance ID: `urn:uuid:550e8400-e29b-41d4-a716-446655440000`"

--- a/packages/core/src/content-negotiation.js
+++ b/packages/core/src/content-negotiation.js
@@ -1,0 +1,79 @@
+/**
+ * HTTP Content Negotiation for RFC 9457 responses
+ * @module content-negotiation
+ */
+
+export const SUPPORTED_FORMATS = [
+  "application/problem+json",
+  "application/json",
+  "text/markdown"
+];
+
+/**
+ * Parse Accept header into sorted list of media types with q-values
+ * @param {string} acceptHeader - The Accept header value
+ * @returns {Array<{type: string, q: number}>} Sorted by q descending
+ */
+export function parseAcceptHeader(acceptHeader) {
+  if (!acceptHeader || acceptHeader.trim() === "") {
+    return [];
+  }
+
+  const types = acceptHeader.split(",").map((part) => {
+    const [type, ...params] = part.trim().split(";");
+    const typeClean = type.trim();
+
+    // Parse q-value, default to 1.0
+    let q = 1;
+    for (const param of params) {
+      const [key, value] = param.trim().split("=");
+      if (key.trim() === "q" && value) {
+        const qValue = parseFloat(value.trim());
+        if (!isNaN(qValue) && qValue >= 0 && qValue <= 1) {
+          q = qValue;
+        }
+      }
+    }
+
+    return { type: typeClean, q };
+  });
+
+  // Sort by q descending
+  return types.sort((a, b) => b.q - a.q);
+}
+
+/**
+ * Select best response format based on Accept header
+ * @param {string} acceptHeader - The Accept header value
+ * @returns {string} Selected format
+ */
+export function selectResponseFormat(acceptHeader) {
+  const parsed = parseAcceptHeader(acceptHeader);
+
+  if (parsed.length === 0) {
+    return "application/problem+json";
+  }
+
+  // Check each preferred type in order
+  for (const { type } of parsed) {
+    // Wildcard fallback
+    if (type === "*/*") {
+      return "application/problem+json";
+    }
+
+    // Direct match
+    if (SUPPORTED_FORMATS.includes(type)) {
+      return type;
+    }
+
+    // Check for type/* wildcard (e.g., application/*)
+    if (type.endsWith("/*")) {
+      const prefix = type.slice(0, -1);
+      const match = SUPPORTED_FORMATS.find((fmt) => fmt.startsWith(prefix));
+      if (match) return match;
+    }
+  }
+
+  // No match found, use default
+  return "application/problem+json";
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -20,5 +20,12 @@ export { DEFAULT_OPTIONS as defaultOptions } from "./default-options.js";
 export {
   conflictErrorResponse,
   keyValidationErrorResponse,
-  missingKeyResponse
+  missingKeyResponse,
+  storeUnavailableResponse
 } from "./problem-json.js";
+export {
+  parseAcceptHeader,
+  selectResponseFormat,
+  SUPPORTED_FORMATS
+} from "./content-negotiation.js";
+export { formatAsMarkdown } from "./markdown-formatter.js";

--- a/packages/core/src/markdown-formatter.js
+++ b/packages/core/src/markdown-formatter.js
@@ -1,0 +1,62 @@
+/**
+ * Format RFC 9457 problem details as markdown with YAML frontmatter
+ * Optimized for AI agent consumption
+ * @module markdown-formatter
+ */
+
+/**
+ * Convert a problem details object to markdown format
+ * @param {Object} problem - RFC 9457 problem details
+ * @param {string} problem.type - Problem type URI
+ * @param {string} problem.title - Short title
+ * @param {string} [problem.detail] - Detailed explanation
+ * @param {number} problem.status - HTTP status code
+ * @param {string} problem.instance - Error instance URI
+ * @param {boolean} problem.retryable - Whether retry might succeed
+ * @param {string} [problem.idempotency_key] - The idempotency key
+ * @returns {string} Markdown document with YAML frontmatter
+ */
+export function formatAsMarkdown(problem) {
+  const { type, title, detail, status, instance, retryable, idempotency_key } =
+    problem;
+
+  // Build YAML frontmatter with known fields only
+  const frontmatter = {
+    type,
+    status,
+    instance,
+    retryable
+  };
+
+  if (idempotency_key !== undefined) {
+    frontmatter.idempotency_key = idempotency_key;
+  }
+
+  const yamlLines = Object.entries(frontmatter).map(([key, value]) => {
+    if (typeof value === "string") {
+      return `${key}: "${value}"`;
+    }
+    return `${key}: ${value}`;
+  });
+
+  // Build guidance based on retryable flag
+  const guidance = retryable
+    ? `**Wait and retry.** This error may be transient. Wait a moment before retrying with the same idempotency key.`
+    : `**Correct the issue.** This error requires changes to your request. Do not retry with the same idempotency key until the issue is resolved.`;
+
+  // Build markdown body
+  return `---
+${yamlLines.join("\n")}
+---
+
+# ${title}
+
+## What Happened
+
+${detail || title}
+
+## What You Should Do
+
+${guidance}
+`;
+}

--- a/packages/core/src/problem-json.js
+++ b/packages/core/src/problem-json.js
@@ -1,5 +1,5 @@
 /**
- * RFC 7807 Problem Details for HTTP APIs
+ * RFC 9457 Problem Details for HTTP APIs
  * @module problem-json
  */
 
@@ -9,55 +9,98 @@ const SPEC_URL =
 /**
  * @param {number} status - HTTP status code (409 or 422)
  * @param {string} error - Error message
- * @returns {Object} RFC 7807 problem response
+ * @param {Object} options
+ * @param {string} options.instance - Unique error instance URI
+ * @param {string} [options.idempotencyKey] - The idempotency key from request
+ * @returns {Object} RFC 9457 problem response
  */
-export function conflictErrorResponse(status, error) {
+export function conflictErrorResponse(status, error, options = {}) {
+  const { instance, idempotencyKey } = options;
   const isConcurrent = error.includes("already being processed");
 
-  if (status === 409 && isConcurrent) {
-    return {
-      type: `${SPEC_URL}#section-2.6`,
-      title: "A request is outstanding for this Idempotency-Key",
-      detail: error
-    };
-  }
-
-  if (status === 409) {
-    return {
-      type: `${SPEC_URL}#section-2.2`,
-      title: "Fingerprint conflict",
-      detail: error
-    };
-  }
-
-  // 422
-  return {
-    type: `${SPEC_URL}#section-2.2`,
-    title: "Idempotency-Key is already used",
-    detail: error
+  const response = {
+    type: `${SPEC_URL}#section-${status === 409 && isConcurrent ? "2.6" : "2.2"}`,
+    title: isConcurrent
+      ? "A request is outstanding for this Idempotency-Key"
+      : status === 409
+        ? "Fingerprint conflict"
+        : "Idempotency-Key is already used",
+    detail: error,
+    status,
+    instance,
+    retryable: isConcurrent
   };
+
+  if (idempotencyKey !== undefined) {
+    response.idempotency_key = idempotencyKey;
+  }
+
+  return response;
 }
 
 /**
- * @returns {Object} RFC 7807 problem response
+ * @param {Object} options
+ * @param {number} options.status - HTTP status code
+ * @param {string} options.instance - Unique error instance URI
+ * @returns {Object} RFC 9457 problem response
  */
-export function missingKeyResponse() {
+export function missingKeyResponse(options = {}) {
+  const { status, instance } = options;
+
   return {
     type: `${SPEC_URL}#section-2.1`,
     title: "Idempotency-Key is missing",
     detail:
-      "This operation is idempotent and it requires correct usage of Idempotency Key."
+      "This operation is idempotent and it requires correct usage of Idempotency Key.",
+    status,
+    instance,
+    retryable: false
   };
 }
 
 /**
  * @param {string} error - Validation error message
- * @returns {Object} RFC 7807 problem response
+ * @param {Object} options
+ * @param {number} options.status - HTTP status code
+ * @param {string} options.instance - Unique error instance URI
+ * @param {string} [options.idempotencyKey] - The idempotency key from request
+ * @returns {Object} RFC 9457 problem response
  */
-export function keyValidationErrorResponse(error) {
-  return {
+export function keyValidationErrorResponse(error, options = {}) {
+  const { status, instance, idempotencyKey } = options;
+
+  const response = {
     type: `${SPEC_URL}#section-2.1`,
     title: "Invalid Idempotency-Key",
-    detail: error
+    detail: error,
+    status,
+    instance,
+    retryable: false
+  };
+
+  if (idempotencyKey !== undefined) {
+    response.idempotency_key = idempotencyKey;
+  }
+
+  return response;
+}
+
+/**
+ * Store unavailable error (infrastructure error, not in spec)
+ * @param {Object} options
+ * @param {number} options.status - HTTP status code
+ * @param {string} options.instance - Unique error instance URI
+ * @returns {Object} RFC 9457 problem response
+ */
+export function storeUnavailableResponse(options = {}) {
+  const { status, instance } = options;
+
+  return {
+    type: "https://js.idempot.dev/problems#store-unavailable",
+    title: "Service temporarily unavailable",
+    detail: "The idempotency store is temporarily unavailable. Please retry.",
+    status,
+    instance,
+    retryable: true
   };
 }

--- a/packages/core/tests/content-negotiation.test.js
+++ b/packages/core/tests/content-negotiation.test.js
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  parseAcceptHeader,
+  selectResponseFormat
+} from "../src/content-negotiation.js";
+
+describe("content-negotiation", () => {
+  describe("parseAcceptHeader", () => {
+    it("should parse single type without q-value", () => {
+      const result = parseAcceptHeader("application/json");
+      assert.deepStrictEqual(result, [{ type: "application/json", q: 1 }]);
+    });
+
+    it("should parse multiple types with q-values", () => {
+      const result = parseAcceptHeader(
+        "text/markdown;q=0.9, application/json;q=0.8"
+      );
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(result[0].type, "text/markdown");
+      assert.strictEqual(result[0].q, 0.9);
+      assert.strictEqual(result[1].type, "application/json");
+      assert.strictEqual(result[1].q, 0.8);
+    });
+
+    it("should sort by q-value descending", () => {
+      const result = parseAcceptHeader(
+        "application/json;q=0.5, text/markdown;q=0.9"
+      );
+      assert.strictEqual(result[0].type, "text/markdown");
+      assert.strictEqual(result[1].type, "application/json");
+    });
+
+    it("should handle wildcard */*", () => {
+      const result = parseAcceptHeader("*/*");
+      assert.deepStrictEqual(result, [{ type: "*/*", q: 1 }]);
+    });
+
+    it("should return empty array for empty header", () => {
+      const result = parseAcceptHeader("");
+      assert.deepStrictEqual(result, []);
+    });
+  });
+
+  describe("selectResponseFormat", () => {
+    it("should default to problem+json for empty header", () => {
+      const result = selectResponseFormat("");
+      assert.strictEqual(result, "application/problem+json");
+    });
+
+    it("should select problem+json when specified", () => {
+      const result = selectResponseFormat("application/problem+json");
+      assert.strictEqual(result, "application/problem+json");
+    });
+
+    it("should select markdown when specified", () => {
+      const result = selectResponseFormat("text/markdown");
+      assert.strictEqual(result, "text/markdown");
+    });
+
+    it("should select based on highest q-value", () => {
+      const result = selectResponseFormat(
+        "application/json;q=0.8, text/markdown;q=0.9"
+      );
+      assert.strictEqual(result, "text/markdown");
+    });
+
+    it("should fallback to problem+json for unsupported types", () => {
+      const result = selectResponseFormat("text/html");
+      assert.strictEqual(result, "application/problem+json");
+    });
+
+    it("should handle */* wildcard", () => {
+      const result = selectResponseFormat("*/*");
+      assert.strictEqual(result, "application/problem+json");
+    });
+
+    it("should handle application/* wildcard", () => {
+      const result = selectResponseFormat("application/*");
+      assert.ok(result.startsWith("application/"));
+    });
+
+    it("should select json when explicitly requested", () => {
+      const result = selectResponseFormat("application/json");
+      assert.strictEqual(result, "application/json");
+    });
+  });
+});

--- a/packages/core/tests/markdown-formatter.test.js
+++ b/packages/core/tests/markdown-formatter.test.js
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { formatAsMarkdown } from "../src/markdown-formatter.js";
+
+describe("markdown-formatter", () => {
+  it("should format problem JSON as markdown with YAML frontmatter", () => {
+    const problem = {
+      type: "https://example.com/probs/out-of-credit",
+      title: "You do not have enough credit",
+      detail: "Your current balance is 30",
+      status: 403,
+      instance: "urn:uuid:test-123",
+      retryable: false
+    };
+
+    const result = formatAsMarkdown(problem);
+
+    assert.ok(result.startsWith("---\n"));
+    assert.ok(
+      result.includes('type: "https://example.com/probs/out-of-credit"')
+    );
+    assert.ok(result.includes("status: 403"));
+    assert.ok(result.includes('instance: "urn:uuid:test-123"'));
+    assert.ok(result.includes("retryable: false"));
+    assert.ok(result.includes("# You do not have enough credit"));
+    assert.ok(result.includes("## What Happened"));
+    assert.ok(result.includes("Your current balance is 30"));
+  });
+
+  it("should include retryable guidance", () => {
+    const problem = {
+      type: "https://example.com/probs/rate-limited",
+      title: "Rate limited",
+      detail: "Too many requests",
+      status: 429,
+      instance: "urn:uuid:test-456",
+      retryable: true
+    };
+
+    const result = formatAsMarkdown(problem);
+
+    assert.ok(result.includes("retryable: true"));
+    assert.ok(result.includes("Wait and retry"));
+  });
+
+  it("should include non-retryable guidance", () => {
+    const problem = {
+      type: "https://example.com/probs/invalid-key",
+      title: "Invalid key",
+      detail: "Key format is wrong",
+      status: 400,
+      instance: "urn:uuid:test-789",
+      retryable: false
+    };
+
+    const result = formatAsMarkdown(problem);
+
+    assert.ok(result.includes("retryable: false"));
+    assert.ok(result.includes("Correct the issue"));
+  });
+
+  it("should include idempotency_key when present", () => {
+    const problem = {
+      type: "https://example.com/probs/conflict",
+      title: "Conflict",
+      status: 409,
+      instance: "urn:uuid:test-abc",
+      retryable: false,
+      idempotency_key: "my-key-123"
+    };
+
+    const result = formatAsMarkdown(problem);
+
+    assert.ok(result.includes('idempotency_key: "my-key-123"'));
+  });
+});

--- a/packages/core/tests/problem-json.test.js
+++ b/packages/core/tests/problem-json.test.js
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  conflictErrorResponse,
+  keyValidationErrorResponse,
+  missingKeyResponse,
+  storeUnavailableResponse
+} from "../src/problem-json.js";
+
+describe("problem-json", () => {
+  describe("missingKeyResponse", () => {
+    it("should include RFC 9457 fields", () => {
+      const result = missingKeyResponse({
+        status: 400,
+        instance: "urn:uuid:test-123"
+      });
+
+      assert.strictEqual(result.status, 400);
+      assert.strictEqual(result.instance, "urn:uuid:test-123");
+      assert.strictEqual(result.retryable, false);
+      assert.ok(result.type.includes("section-2.1"));
+    });
+  });
+
+  describe("keyValidationErrorResponse", () => {
+    it("should include idempotency_key when provided", () => {
+      const result = keyValidationErrorResponse("Key too short", {
+        status: 400,
+        instance: "urn:uuid:test-456",
+        idempotencyKey: "short"
+      });
+
+      assert.strictEqual(result.idempotency_key, "short");
+      assert.strictEqual(result.retryable, false);
+    });
+  });
+
+  describe("conflictErrorResponse", () => {
+    it("should mark concurrent requests as retryable", () => {
+      const result = conflictErrorResponse(
+        409,
+        "A request with this idempotency key is already being processed",
+        { instance: "urn:uuid:test-789" }
+      );
+
+      assert.strictEqual(result.retryable, true);
+      assert.strictEqual(result.status, 409);
+    });
+
+    it("should mark fingerprint conflict as not retryable", () => {
+      const result = conflictErrorResponse(
+        409,
+        "This request was already processed with a different idempotency key",
+        { instance: "urn:uuid:test-abc" }
+      );
+
+      assert.strictEqual(result.retryable, false);
+    });
+
+    it("should mark 422 as not retryable", () => {
+      const result = conflictErrorResponse(422, "Idempotency key reused", {
+        instance: "urn:uuid:test-def"
+      });
+
+      assert.strictEqual(result.retryable, false);
+      assert.strictEqual(result.status, 422);
+    });
+  });
+
+  describe("storeUnavailableResponse", () => {
+    it("should use custom type URI and be retryable", () => {
+      const result = storeUnavailableResponse({
+        status: 503,
+        instance: "urn:uuid:test-503"
+      });
+
+      assert.strictEqual(
+        result.type,
+        "https://js.idempot.dev/problems#store-unavailable"
+      );
+      assert.strictEqual(result.retryable, true);
+    });
+  });
+});

--- a/packages/frameworks/express/express-middleware.test.js
+++ b/packages/frameworks/express/express-middleware.test.js
@@ -5,6 +5,115 @@ import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
 
+// Content negotiation tests
+test("express - returns markdown format when Accept: text/markdown", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = express();
+  app.use(express.json());
+
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (req, res) => res.json({ ok: true }));
+
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const response = await new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "localhost",
+        port,
+        path: "/test",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/markdown"
+        }
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: data
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(JSON.stringify({}));
+    req.end();
+  });
+
+  t.equal(response.status, 400, "should return 400");
+  t.ok(
+    response.headers["content-type"].includes("text/markdown"),
+    "should return markdown content type"
+  );
+  t.ok(response.body.includes("---"), "should have YAML frontmatter");
+
+  server.close();
+  await store.close();
+});
+
+test("express - returns JSON format when Accept: application/json", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = express();
+  app.use(express.json());
+
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (req, res) => res.json({ ok: true }));
+
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const response = await new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "localhost",
+        port,
+        path: "/test",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json"
+        }
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          const contentType = res.headers["content-type"] || "";
+          const isJson =
+            contentType.includes("application/json") ||
+            contentType.includes("application/problem+json");
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: isJson ? JSON.parse(data) : data
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(JSON.stringify({}));
+    req.end();
+  });
+
+  t.equal(response.status, 400, "should return 400");
+  t.ok(
+    response.headers["content-type"].includes("application/json"),
+    "should return JSON content type"
+  );
+  t.ok(response.body.type, "should have type field in JSON body");
+
+  server.close();
+  await store.close();
+});
+
 // Run shared adapter test suite
 runAdapterTests({
   name: "express",

--- a/packages/frameworks/express/index.js
+++ b/packages/frameworks/express/index.js
@@ -5,6 +5,7 @@
  */
 
 // @ts-nocheck
+import { randomUUID } from "node:crypto";
 import {
   generateFingerprint,
   validateExcludeFields,
@@ -18,7 +19,10 @@ import {
   defaultOptions,
   conflictErrorResponse,
   keyValidationErrorResponse,
-  missingKeyResponse
+  missingKeyResponse,
+  storeUnavailableResponse,
+  selectResponseFormat,
+  formatAsMarkdown
 } from "@idempot/core";
 
 /**
@@ -28,6 +32,42 @@ import {
  * @type {string}
  */
 const HEADER_NAME = "idempotency-key";
+
+/**
+ * Send error response in appropriate format based on Accept header
+ * @param {import("express").Response} res - Express response
+ * @param {number} status - HTTP status code
+ * @param {Object} problem - RFC 9457 problem details
+ */
+function sendErrorResponse(res, status, problem) {
+  const acceptHeader = res.req.headers["accept"] || "";
+  const format = selectResponseFormat(acceptHeader);
+
+  if (format === "text/markdown") {
+    res
+      .status(status)
+      .set("Content-Type", "text/markdown; charset=utf-8")
+      .send(formatAsMarkdown(problem));
+  } else {
+    const contentType =
+      format === "application/problem+json"
+        ? "application/problem+json"
+        : "application/json";
+
+    res
+      .status(status)
+      .set("Content-Type", `${contentType}; charset=utf-8`)
+      .json(problem);
+  }
+}
+
+/**
+ * Generate unique instance identifier
+ * @returns {string} URI in the format urn:uuid:<uuid>
+ */
+function generateInstanceId() {
+  return `urn:uuid:${randomUUID()}`;
+}
 
 /**
  * Express middleware for idempotency
@@ -62,12 +102,15 @@ export function idempotency(options = {}) {
     }
 
     const key = /** @type {string} */ (req.headers[HEADER_NAME]);
+    const instanceId = generateInstanceId();
+
     if (key === undefined) {
       if (opts.required) {
-        res
-          .status(400)
-          .set("Content-Type", "application/problem+json")
-          .json(missingKeyResponse());
+        const problem = missingKeyResponse({
+          status: 400,
+          instance: instanceId
+        });
+        sendErrorResponse(res, 400, problem);
         return;
       }
       next();
@@ -79,14 +122,15 @@ export function idempotency(options = {}) {
       maxKeyLength
     });
     if (!keyValidation.valid) {
-      res
-        .status(400)
-        .set("Content-Type", "application/problem+json")
-        .json(
-          keyValidationErrorResponse(
-            /** @type {string} */ (keyValidation.error)
-          )
-        );
+      const problem = keyValidationErrorResponse(
+        /** @type {string} */ (keyValidation.error),
+        {
+          status: 400,
+          instance: instanceId,
+          idempotencyKey: key
+        }
+      );
+      sendErrorResponse(res, 400, problem);
       return;
     }
 
@@ -101,21 +145,25 @@ export function idempotency(options = {}) {
     try {
       lookup = await resilientStore.lookup(key, fingerprint);
     } catch {
-      res.status(503).json({ error: "Service temporarily unavailable" });
+      const problem = storeUnavailableResponse({
+        status: 503,
+        instance: instanceId
+      });
+      sendErrorResponse(res, 503, problem);
       return;
     }
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
     if (conflict.conflict) {
-      res
-        .status(/** @type {number} */ (conflict.status))
-        .set("Content-Type", "application/problem+json")
-        .json(
-          conflictErrorResponse(
-            /** @type {number} */ (conflict.status),
-            conflict.error
-          )
-        );
+      const problem = conflictErrorResponse(
+        /** @type {number} */ (conflict.status),
+        /** @type {string} */ (conflict.error),
+        {
+          instance: instanceId,
+          idempotencyKey: key
+        }
+      );
+      sendErrorResponse(res, /** @type {number} */ (conflict.status), problem);
       return;
     }
 
@@ -134,7 +182,11 @@ export function idempotency(options = {}) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
       } catch {
-        res.status(503).json({ error: "Service temporarily unavailable" });
+        const problem = storeUnavailableResponse({
+          status: 503,
+          instance: instanceId
+        });
+        sendErrorResponse(res, 503, problem);
         return;
       }
 

--- a/packages/frameworks/fastify/fastify-middleware.test.js
+++ b/packages/frameworks/fastify/fastify-middleware.test.js
@@ -44,6 +44,77 @@ runAdapterTests({
   createStore: () => new SqliteIdempotencyStore({ path: ":memory:" })
 });
 
+// Content negotiation tests
+test("fastify - returns markdown format when Accept: text/markdown", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async (request, reply) => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/markdown"
+    }
+  });
+
+  t.equal(response.statusCode, 400, "should return 400");
+  t.ok(
+    response.headers["content-type"].includes("text/markdown"),
+    "should return markdown content type"
+  );
+  t.ok(response.body.includes("---"), "should have YAML frontmatter");
+
+  await store.close();
+});
+
+test("fastify - returns JSON format when Accept: application/json", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async (request, reply) => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    }
+  });
+
+  const contentType = response.headers["content-type"] || "";
+  const isJson =
+    contentType.includes("application/json") ||
+    contentType.includes("application/problem+json");
+  const body = isJson ? response.json() : response.body;
+
+  t.equal(response.statusCode, 400, "should return 400");
+  t.ok(
+    contentType.includes("application/json"),
+    "should return JSON content type"
+  );
+  t.ok(body.type, "should have type field in JSON body");
+
+  await store.close();
+});
+
 // Fastify-specific tests
 // These tests cover Fastify-specific handler patterns that differ from the
 // generic (req, res) interface used by the shared test suite.

--- a/packages/frameworks/fastify/index.js
+++ b/packages/frameworks/fastify/index.js
@@ -5,6 +5,7 @@
  * @typedef {import("@idempot/core").IdempotencyOptions} IdempotencyOptions
  */
 
+import { randomUUID } from "node:crypto";
 import {
   generateFingerprint,
   validateExcludeFields,
@@ -18,10 +19,50 @@ import {
   defaultOptions,
   conflictErrorResponse,
   keyValidationErrorResponse,
-  missingKeyResponse
+  missingKeyResponse,
+  storeUnavailableResponse,
+  selectResponseFormat,
+  formatAsMarkdown
 } from "@idempot/core";
 
 const HEADER_NAME = "idempotency-key";
+
+/**
+ * Send error response in appropriate format based on Accept header
+ * @param {import("fastify").FastifyReply} reply - Fastify reply
+ * @param {number} status - HTTP status code
+ * @param {Object} problem - RFC 9457 problem details
+ * @returns {import("fastify").FastifyReply}
+ */
+function sendErrorResponse(reply, status, problem) {
+  const acceptHeader = reply.request.headers["accept"] || "";
+  const format = selectResponseFormat(acceptHeader);
+
+  if (format === "text/markdown") {
+    return reply
+      .code(status)
+      .header("Content-Type", "text/markdown; charset=utf-8")
+      .send(formatAsMarkdown(problem));
+  } else {
+    const contentType =
+      format === "application/problem+json"
+        ? "application/problem+json"
+        : "application/json";
+
+    return reply
+      .code(status)
+      .header("Content-Type", `${contentType}; charset=utf-8`)
+      .send(problem);
+  }
+}
+
+/**
+ * Generate unique instance identifier
+ * @returns {string} URI in the format urn:uuid:<uuid>
+ */
+function generateInstanceId() {
+  return `urn:uuid:${randomUUID()}`;
+}
 
 /**
  * Fastify middleware for idempotency
@@ -42,15 +83,12 @@ export function idempotency(options = {}) {
   validateExcludeFields(opts.excludeFields);
   validateIdempotencyOptions(opts);
   const store = opts.store;
+  const { minKeyLength, maxKeyLength } = opts;
   const { store: resilientStore, circuit } = withResilience(
     store,
     opts.resilience
   );
 
-  /**
-   * @param {import("fastify").FastifyRequest} request
-   * @param {import("fastify").FastifyReply} reply
-   */
   const middleware = async (request, reply) => {
     const requestMeta = new WeakMap();
     const method = request.method;
@@ -58,35 +96,34 @@ export function idempotency(options = {}) {
       return;
     }
 
-    /**
-     * Fastify returns duplicate headers as a comma-separated string per RFC 7230.
-     * The TypeScript type is string | string[] for compatibility, but Fastify
-     * normalizes to a single string at runtime.
-     */
     const key = /** @type {string} */ (request.headers[HEADER_NAME]);
+    const instanceId = generateInstanceId();
+
     if (key === undefined) {
       if (opts.required) {
-        return reply
-          .code(400)
-          .header("Content-Type", "application/problem+json")
-          .send(missingKeyResponse());
+        const problem = missingKeyResponse({
+          status: 400,
+          instance: instanceId
+        });
+        return sendErrorResponse(reply, 400, problem);
       }
       return;
     }
 
     const keyValidation = validateIdempotencyKey(key, {
-      minKeyLength: opts.minKeyLength,
-      maxKeyLength: opts.maxKeyLength
+      minKeyLength,
+      maxKeyLength
     });
     if (!keyValidation.valid) {
-      return reply
-        .code(400)
-        .header("Content-Type", "application/problem+json")
-        .send(
-          keyValidationErrorResponse(
-            /** @type {string} */ (keyValidation.error)
-          )
-        );
+      const problem = keyValidationErrorResponse(
+        /** @type {string} */ (keyValidation.error),
+        {
+          status: 400,
+          instance: instanceId,
+          idempotencyKey: key
+        }
+      );
+      return sendErrorResponse(reply, 400, problem);
     }
 
     const bodyText = request.body
@@ -100,17 +137,28 @@ export function idempotency(options = {}) {
     try {
       lookup = await resilientStore.lookup(key, fingerprint);
     } catch {
-      return reply.code(503).send({ error: "Service temporarily unavailable" });
+      const problem = storeUnavailableResponse({
+        status: 503,
+        instance: instanceId
+      });
+      return sendErrorResponse(reply, 503, problem);
     }
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
     if (conflict.conflict) {
-      const status = /** @type {409|422} */ (conflict.status);
-      const errorMsg = /** @type {string} */ (conflict.error);
-      return reply
-        .code(status)
-        .header("Content-Type", "application/problem+json")
-        .send(conflictErrorResponse(status, errorMsg));
+      const problem = conflictErrorResponse(
+        /** @type {number} */ (conflict.status),
+        /** @type {string} */ (conflict.error),
+        {
+          instance: instanceId,
+          idempotencyKey: key
+        }
+      );
+      return sendErrorResponse(
+        reply,
+        /** @type {number} */ (conflict.status),
+        problem
+      );
     }
 
     const cached = getCachedResponse(lookup);
@@ -127,9 +175,11 @@ export function idempotency(options = {}) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
       } catch {
-        return reply
-          .code(503)
-          .send({ error: "Service temporarily unavailable" });
+        const problem = storeUnavailableResponse({
+          status: 503,
+          instance: instanceId
+        });
+        return sendErrorResponse(reply, 503, problem);
       }
 
       requestMeta.set(request, { idempotencyKey: key });

--- a/packages/frameworks/hono/hono-middleware.test.js
+++ b/packages/frameworks/hono/hono-middleware.test.js
@@ -1,7 +1,67 @@
 import { Hono } from "hono";
+import { test } from "tap";
 import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+// Content negotiation tests
+test("hono - returns markdown format when Accept: text/markdown", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/markdown"
+    },
+    body: JSON.stringify({})
+  });
+
+  const body = await res.text();
+
+  t.equal(res.status, 400, "should return 400");
+  t.ok(
+    res.headers.get("content-type").includes("text/markdown"),
+    "should return markdown content type"
+  );
+  t.ok(body.includes("---"), "should have YAML frontmatter");
+
+  await store.close();
+});
+
+test("hono - returns JSON format when Accept: application/json", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    },
+    body: JSON.stringify({})
+  });
+
+  const contentType = res.headers.get("content-type") || "";
+  const isJson =
+    contentType.includes("application/json") ||
+    contentType.includes("application/problem+json");
+  const body = isJson ? await res.json() : await res.text();
+
+  t.equal(res.status, 400, "should return 400");
+  t.ok(
+    contentType.includes("application/json"),
+    "should return JSON content type"
+  );
+  t.ok(body.type, "should have type field in JSON body");
+
+  await store.close();
+});
 
 // Run shared adapter test suite
 runAdapterTests({

--- a/packages/frameworks/hono/index.js
+++ b/packages/frameworks/hono/index.js
@@ -4,6 +4,7 @@
  * @typedef {import("@idempot/core").IdempotencyOptions} IdempotencyOptions
  */
 
+import { randomUUID } from "node:crypto";
 import {
   generateFingerprint,
   validateExcludeFields,
@@ -17,7 +18,10 @@ import {
   defaultOptions,
   conflictErrorResponse,
   keyValidationErrorResponse,
-  missingKeyResponse
+  missingKeyResponse,
+  storeUnavailableResponse,
+  selectResponseFormat,
+  formatAsMarkdown
 } from "@idempot/core";
 
 /**
@@ -27,6 +31,41 @@ import {
  * @type {string}
  */
 const HEADER_NAME = "idempotency-key";
+
+/**
+ * Send error response in appropriate format based on Accept header
+ * @param {import("hono").Context} c - Hono context
+ * @param {number} status - HTTP status code
+ * @param {Object} problem - RFC 9457 problem details
+ * @returns {import("hono").Response}
+ */
+function sendErrorResponse(c, status, problem) {
+  const acceptHeader = c.req.header("accept") || "";
+  const format = selectResponseFormat(acceptHeader);
+
+  if (format === "text/markdown") {
+    return c.text(formatAsMarkdown(problem), status, {
+      "Content-Type": "text/markdown; charset=utf-8"
+    });
+  } else {
+    const contentType =
+      format === "application/problem+json"
+        ? "application/problem+json"
+        : "application/json";
+
+    return c.json(problem, status, {
+      "Content-Type": `${contentType}; charset=utf-8`
+    });
+  }
+}
+
+/**
+ * Generate unique instance identifier
+ * @returns {string} URI in the format urn:uuid:<uuid>
+ */
+function generateInstanceId() {
+  return `urn:uuid:${randomUUID()}`;
+}
 
 /**
  * Hono middleware for idempotency
@@ -47,15 +86,12 @@ export function idempotency(options = {}) {
   validateExcludeFields(opts.excludeFields);
   validateIdempotencyOptions(opts);
   const store = opts.store;
+  const { minKeyLength, maxKeyLength } = opts;
   const { store: resilientStore, circuit } = withResilience(
     store,
     opts.resilience
   );
 
-  /**
-   * @param {any} c
-   * @param {() => Promise<void>} next
-   */
   const middleware = async (c, next) => {
     const method = c.req.method;
     if (!shouldProcessRequest(method)) {
@@ -64,28 +100,34 @@ export function idempotency(options = {}) {
     }
 
     const key = c.req.header(HEADER_NAME);
+    const instanceId = generateInstanceId();
+
     if (key === undefined) {
       if (opts.required) {
-        return c.json(missingKeyResponse(), 400, {
-          "Content-Type": "application/problem+json"
+        const problem = missingKeyResponse({
+          status: 400,
+          instance: instanceId
         });
+        return sendErrorResponse(c, 400, problem);
       }
       await next();
       return;
     }
 
     const keyValidation = validateIdempotencyKey(key, {
-      minKeyLength: opts.minKeyLength,
-      maxKeyLength: opts.maxKeyLength
+      minKeyLength,
+      maxKeyLength
     });
     if (!keyValidation.valid) {
-      return c.json(
-        keyValidationErrorResponse(/** @type {string} */ (keyValidation.error)),
-        400,
+      const problem = keyValidationErrorResponse(
+        /** @type {string} */ (keyValidation.error),
         {
-          "Content-Type": "application/problem+json"
+          status: 400,
+          instance: instanceId,
+          idempotencyKey: key
         }
       );
+      return sendErrorResponse(c, 400, problem);
     }
 
     const body = await c.req.text();
@@ -95,16 +137,28 @@ export function idempotency(options = {}) {
     try {
       lookup = await resilientStore.lookup(key, fingerprint);
     } catch {
-      return c.json({ error: "Service temporarily unavailable" }, 503);
+      const problem = storeUnavailableResponse({
+        status: 503,
+        instance: instanceId
+      });
+      return sendErrorResponse(c, 503, problem);
     }
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
     if (conflict.conflict) {
-      const status = /** @type {409|422} */ (conflict.status);
-      const errorMsg = /** @type {string} */ (conflict.error);
-      return c.json(conflictErrorResponse(status, errorMsg), status, {
-        "Content-Type": "application/problem+json"
-      });
+      const problem = conflictErrorResponse(
+        /** @type {number} */ (conflict.status),
+        /** @type {string} */ (conflict.error),
+        {
+          instance: instanceId,
+          idempotencyKey: key
+        }
+      );
+      return sendErrorResponse(
+        c,
+        /** @type {number} */ (conflict.status),
+        problem
+      );
     }
 
     const cached = getCachedResponse(lookup);
@@ -117,7 +171,11 @@ export function idempotency(options = {}) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
       } catch {
-        return c.json({ error: "Service temporarily unavailable" }, 503);
+        const problem = storeUnavailableResponse({
+          status: 503,
+          instance: instanceId
+        });
+        return sendErrorResponse(c, 503, problem);
       }
 
       await next();

--- a/tests/integration/express-sqlite.test.js
+++ b/tests/integration/express-sqlite.test.js
@@ -127,3 +127,26 @@ t.test(
     );
   }
 );
+
+t.test(
+  "Express + SQLite - returns markdown format when requested",
+  async (t) => {
+    const { port } = t.context;
+
+    const response = await makeRequest(port, {
+      idempotencyKey: undefined,
+      body: { foo: "bar" },
+      headers: { Accept: "text/markdown" }
+    });
+
+    t.equal(response.status, 400, "should return 400");
+    t.ok(
+      response.headers["content-type"].includes("text/markdown"),
+      "should return markdown content type"
+    );
+    // Body is now a string (not parsed JSON)
+    t.ok(response.body.includes("---"), "should have YAML frontmatter");
+    t.ok(response.body.includes("type:"), "should have type field");
+    t.ok(response.body.includes("#"), "should have markdown header");
+  }
+);

--- a/tests/integration/hono-postgres.test.js
+++ b/tests/integration/hono-postgres.test.js
@@ -180,9 +180,8 @@ t.test(
     });
 
     t.equal(response2.status, 422, "should return 422");
-    t.equal(
-      response2.headers["content-type"],
-      "application/problem+json",
+    t.ok(
+      response2.headers["content-type"].includes("application/problem+json"),
       "should return problem+json content type"
     );
     t.match(response2.body.type, /idempotency/i, "should have type field");

--- a/tests/integration/shared/request.js
+++ b/tests/integration/shared/request.js
@@ -2,25 +2,36 @@ import http from "http";
 
 export async function makeRequest(port, options) {
   return new Promise((resolve, reject) => {
+    const headers = {
+      "content-type": "application/json",
+      ...options.headers
+    };
+    if (options.idempotencyKey !== undefined) {
+      headers["idempotency-key"] = options.idempotencyKey;
+    }
+
     const req = http.request(
       {
         hostname: "localhost",
         port,
         path: "/api",
         method: "POST",
-        headers: {
-          "idempotency-key": options.idempotencyKey,
-          "content-type": "application/json"
-        }
+        headers
       },
       (res) => {
         let data = "";
         res.on("data", (chunk) => (data += chunk));
         res.on("end", () => {
+          // Parse JSON if content-type indicates JSON
+          const contentType = res.headers["content-type"] || "";
+          const isJson =
+            contentType.includes("application/json") ||
+            contentType.includes("application/problem+json");
+          const body = isJson ? JSON.parse(data) : data;
           resolve({
             status: res.statusCode,
             headers: res.headers,
-            body: JSON.parse(data)
+            body
           });
         });
       }
@@ -31,7 +42,7 @@ export async function makeRequest(port, options) {
   });
 }
 
-export async function makeRequestWithoutKey(port, body) {
+export async function makeRequestWithoutKey(port, body, headers = {}) {
   return new Promise((resolve, reject) => {
     const req = http.request(
       {
@@ -40,17 +51,24 @@ export async function makeRequestWithoutKey(port, body) {
         path: "/api",
         method: "POST",
         headers: {
-          "content-type": "application/json"
+          "content-type": "application/json",
+          ...headers
         }
       },
       (res) => {
         let data = "";
         res.on("data", (chunk) => (data += chunk));
         res.on("end", () => {
+          // Parse JSON if content-type indicates JSON
+          const contentType = res.headers["content-type"] || "";
+          const isJson =
+            contentType.includes("application/json") ||
+            contentType.includes("application/problem+json");
+          const parsedBody = isJson ? JSON.parse(data) : data;
           resolve({
             status: res.statusCode,
             headers: res.headers,
-            body: JSON.parse(data)
+            body: parsedBody
           });
         });
       }


### PR DESCRIPTION
## Summary

This PR upgrades the library from RFC 7807 to RFC 9457 compliance, adding new error response fields and agent-friendly content negotiation.

## Changes

### Core Features
- **RFC 9457 Fields**: All error responses now include:
  - `status` - HTTP status code
  - `instance` - Unique error ID (`urn:uuid:xxx`)
  - `retryable` - Boolean indicating if retry might succeed
  - `idempotency_key` - The request's key (when available)

- **Content Negotiation**: Support `Accept` header with:
  - `application/problem+json` (default)
  - `application/json`
  - `text/markdown` (YAML frontmatter + markdown for AI agents)

- **Type URIs**: Hybrid approach
  - Spec errors → IETF draft sections
  - Infrastructure errors → `https://js.idempot.dev/problems#store-unavailable`

### Framework Updates
All framework adapters updated:
- Express
- Hono  
- Fastify

### Documentation
- README updated with RFC 9457 section and curl examples
- New comprehensive error reference page (`docs/reference/errors.md`)
- VitePress sidebar updated

## Backward Compatibility

This is a **MINOR** release (backward compatible):
- All new fields are optional per RFC 9457
- Existing clients ignoring unknown fields continue to work
- No breaking changes to existing behavior

## Testing

- Core module tests added
- Content negotiation tests added
- Markdown formatter tests added
- Integration tests updated
- All tests passing

## Example

**JSON response (default):**
```json
{
  "type": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1",
  "title": "Idempotency-Key is missing",
  "detail": "This operation is idempotent and it requires correct usage of Idempotency Key.",
  "status": 400,
  "instance": "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
  "retryable": false
}
```

**Markdown format (for AI agents):**
```markdown
---
type: "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07#section-2.1"
status: 400
instance: "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
retryable: false
---

# Idempotency-Key is missing

## What Happened
This operation is idempotent and it requires correct usage of Idempotency Key.

## What You Should Do
**Correct the issue.** This error requires changes to your request...
```

## Related

- RFC 9457: https://datatracker.ietf.org/doc/html/rfc9457
- Cloudflare blog post on agent-friendly errors: https://blog.cloudflare.com/rfc-9457-agent-error-pages/