### PR TITLE
docs: move error reference to guide section

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -11,7 +11,8 @@ const docsSidebar = [
       { text: "Overview", link: "/guide/" },
       { text: "Installation", link: "/guide/installation" },
       { text: "Configuration", link: "/guide/configuration" },
-      { text: "Sharing Middleware", link: "/guide/shared-middleware" }
+      { text: "Sharing Middleware", link: "/guide/shared-middleware" },
+      { text: "Error Reference", link: "/reference/errors" }
     ]
   },
   {
@@ -35,8 +36,7 @@ const docsSidebar = [
   {
     text: "Reference",
     items: [
-      { text: "Core", link: "/reference/core" },
-      { text: "Error Reference", link: "/reference/errors" }
+      { text: "Core", link: "/reference/core" }
     ]
   }
 ];


### PR DESCRIPTION
## Summary

Move the Error Reference documentation from the Reference section to the Guide section in the VitePress sidebar.

## Changes

- Added "Error Reference" to the Guide section (after "Sharing Middleware")
- Removed "Error Reference" from the Reference section (now only contains "Core")

This positions the error reference documentation alongside other user-facing guide content for better discoverability.