### PR TITLE
Support `Bun.serve` by wrapping Bun request handlers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,7 @@ idempot-js/
 │   ├── frameworks/              # Framework adapters
 │   │   ├── hono/
 │   │   ├── express/
+│   │   ├── bun/
 │   │   └── fastify/
 │   │
 │   └── stores/                  # Storage backend implementations
@@ -128,6 +129,15 @@ Each framework adapter implements the idempotency middleware pattern for its fra
 - Accesses request via `req` and `res` objects
 - Handles async handlers properly
 - Supports `preHandler` style for Fastify compatibility
+
+### Bun Adapter (`packages/frameworks/bun/`)
+
+**Key characteristics:**
+
+- Uses Bun's `Request => Response` handler pattern
+- Returns a wrapper function that wraps handlers with idempotency enforcement
+- Re-creates the request after body consumption so handlers can read the body
+- Exposes circuit breaker via `wrap.circuit`
 
 ### Fastify Adapter (`packages/frameworks/fastify/`)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This approach simplifies maintenance while giving TypeScript users an excellent 
 | Category       | Options                                                             |
 | -------------- | ------------------------------------------------------------------- |
 | **Runtimes**   | Node.js, Bun, Deno (Lambda & Cloudflare Workers planned)            |
-| **Frameworks** | Express, Hono, Fastify                                              |
+| **Frameworks** | Express, Hono, Fastify, Bun Server                                  |
 | **Stores**     | Redis, PostgreSQL, MySQL, SQLite (DynamoDB & Cloudflare KV planned) |
 
 ## Response Headers

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -20,7 +20,8 @@ const docsSidebar = [
     items: [
       { text: "Express", link: "/frameworks/express" },
       { text: "Fastify", link: "/frameworks/fastify" },
-      { text: "Hono", link: "/frameworks/hono" }
+      { text: "Hono", link: "/frameworks/hono" },
+      { text: "Bun", link: "/frameworks/bun" }
     ]
   },
   {

--- a/docs/frameworks/bun.md
+++ b/docs/frameworks/bun.md
@@ -26,8 +26,8 @@ Bun.serve({
       const body = await req.json();
       const orderId = crypto.randomUUID();
       return Response.json({ id: orderId, ...body }, { status: 201 });
-    }),
-  },
+    })
+  }
 });
 ```
 
@@ -64,14 +64,20 @@ Bun.serve({
   routes: {
     "/orders": withIdempotency(async (req) => {
       const body = await req.json();
-      return Response.json({ id: crypto.randomUUID(), ...body }, { status: 201 });
+      return Response.json(
+        { id: crypto.randomUUID(), ...body },
+        { status: 201 }
+      );
     }),
 
     "/payments": withIdempotency(async (req) => {
       const body = await req.json();
-      return Response.json({ id: crypto.randomUUID(), ...body }, { status: 201 });
-    }),
-  },
+      return Response.json(
+        { id: crypto.randomUUID(), ...body },
+        { status: 201 }
+      );
+    })
+  }
 });
 ```
 

--- a/docs/frameworks/bun.md
+++ b/docs/frameworks/bun.md
@@ -1,0 +1,86 @@
+---
+title: Bun Handler - idempot-js
+description: Add IETF-compliant idempotency to Bun.serve applications. Wraps native Request/Response handlers with Redis, PostgreSQL, MySQL, SQLite, or Bun SQL storage backends.
+---
+
+# Bun
+
+## Installation
+
+```bash
+bun add @idempot/bun-handler @idempot/bun-sql-store
+```
+
+## Usage
+
+```javascript
+import { idempotency } from "@idempot/bun-handler";
+import { BunSqlIdempotencyStore } from "@idempot/bun-sql-store";
+
+const store = new BunSqlIdempotencyStore("sqlite://:memory:");
+const withIdempotency = idempotency({ store });
+
+Bun.serve({
+  routes: {
+    "/orders": withIdempotency(async (req) => {
+      const body = await req.json();
+      const orderId = crypto.randomUUID();
+      return Response.json({ id: orderId, ...body }, { status: 201 });
+    }),
+  },
+});
+```
+
+Unlike Express/Fastify/Hono middleware, `idempotency()` returns a **handler wrapper** rather than a middleware function. Call it once per route to wrap the handler directly.
+
+## API
+
+### `idempotency(options)`
+
+Creates a handler wrapper for idempotency enforcement.
+
+**Options:**
+
+- `store` (required): Storage backend implementing `IdempotencyStore`
+- `required`: Whether idempotency key is required (default: `true`)
+- `ttlMs`: Time-to-live for idempotency records in milliseconds
+- `excludeFields`: Fields to exclude from fingerprint calculation
+- `resilience`: Circuit breaker and retry options
+
+**Returns:** A function `(handler) => handler` that wraps a `Request => Response` handler. The returned wrapper function has a `circuit` property for circuit-breaker monitoring.
+
+## Multiple Routes
+
+Call `idempotency()` once and reuse the wrapper across routes:
+
+```javascript
+import { idempotency } from "@idempot/bun-handler";
+import { BunSqlIdempotencyStore } from "@idempot/bun-sql-store";
+
+const store = new BunSqlIdempotencyStore("sqlite://:memory:");
+const withIdempotency = idempotency({ store });
+
+Bun.serve({
+  routes: {
+    "/orders": withIdempotency(async (req) => {
+      const body = await req.json();
+      return Response.json({ id: crypto.randomUUID(), ...body }, { status: 201 });
+    }),
+
+    "/payments": withIdempotency(async (req) => {
+      const body = await req.json();
+      return Response.json({ id: crypto.randomUUID(), ...body }, { status: 201 });
+    }),
+  },
+});
+```
+
+## Circuit Breaker
+
+The wrapper exposes the underlying circuit breaker for monitoring:
+
+```javascript
+const withIdempotency = idempotency({ store });
+
+console.log(withIdempotency.circuit.stats);
+```

--- a/package.json
+++ b/package.json
@@ -106,5 +106,10 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  }
+  },
+  "workspaces": [
+    "packages/*",
+    "packages/frameworks/*",
+    "packages/stores/*"
+  ]
 }

--- a/packages/frameworks/bun/LICENSE
+++ b/packages/frameworks/bun/LICENSE
@@ -1,0 +1,27 @@
+(The BSD License)
+
+Copyright (c) 2026, Morgan Roderick, morgan@roderick.dk
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Morgan Roderick nor the names of contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/frameworks/bun/README.md
+++ b/packages/frameworks/bun/README.md
@@ -33,8 +33,8 @@ Bun.serve({
       const orderId = crypto.randomUUID();
       const body = await req.json();
       return Response.json({ id: orderId, ...body }, { status: 201 });
-    }),
-  },
+    })
+  }
 });
 ```
 

--- a/packages/frameworks/bun/README.md
+++ b/packages/frameworks/bun/README.md
@@ -1,0 +1,85 @@
+# @idempot/bun-handler
+
+Bun.serve handler wrapper for idempotency.
+
+## Installation
+
+```bash
+npm install @idempot/bun-handler
+```
+
+### Available Stores
+
+Choose a storage backend that fits your infrastructure:
+
+- `@idempot/sqlite-store` - great for development and single-node deployments
+- `@idempot/redis-store`
+- `@idempot/postgres-store`
+- `@idempot/mysql-store`
+- `@idempot/bun-sql-store` - Bun runtime
+
+## Usage
+
+```javascript
+import { idempotency } from "@idempot/bun-handler";
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+const store = new SqliteIdempotencyStore({ path: ":memory:" });
+const withIdempotency = idempotency({ store });
+
+Bun.serve({
+  routes: {
+    "/orders": withIdempotency(async (req) => {
+      const orderId = crypto.randomUUID();
+      const body = await req.json();
+      return Response.json({ id: orderId, ...body }, { status: 201 });
+    }),
+  },
+});
+```
+
+## API
+
+### `idempotency(options)`
+
+Creates a handler wrapper for idempotency.
+
+**Options:**
+
+- `store` (required): Storage backend implementing `IdempotencyStore`
+- `headerName`: Header name for idempotency key (default: `"Idempotency-Key"`)
+- `required`: Whether idempotency key is required (default: `false`)
+- `ttlMs`: Time-to-live for idempotency records in milliseconds
+- `excludeFields`: Fields to exclude from fingerprint calculation
+- `resilience`: Circuit breaker and retry options
+
+**Returns:** A wrapper function that accepts a `Request => Response` handler. The wrapper has a `circuit` property for monitoring.
+
+## TypeScript Support
+
+This library uses JavaScript with JSDoc comments for type information. Enable `allowJs` in your TypeScript configuration to use these types directly—no separate .d.ts files needed.
+
+To use this library in a TypeScript project:
+
+1. Add these settings to your `tsconfig.json`:
+
+   ```json
+   {
+     "allowJs": true,
+     "checkJs": true
+   }
+   ```
+
+2. Import the library as you normally would:
+
+   ```typescript
+   import { idempotency } from "@idempot/bun-handler";
+   ```
+
+3. JSDoc comments provide full type safety: parameter types, return types, and detailed documentation in your IDE.
+
+This approach simplifies maintenance while giving TypeScript users an excellent developer experience.
+
+## License
+
+BSD-3-Clause

--- a/packages/frameworks/bun/bun-handler.test.js
+++ b/packages/frameworks/bun/bun-handler.test.js
@@ -1,0 +1,167 @@
+import { test } from "tap";
+import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
+import { idempotency } from "./index.js";
+import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+
+test("bun - returns markdown format when Accept: text/markdown", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const wrap = idempotency({ store, required: true });
+  const handler = wrap(async () => Response.json({ ok: true }));
+
+  const res = await handler(
+    new Request("http://localhost/test", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/markdown"
+      },
+      body: JSON.stringify({})
+    })
+  );
+
+  const body = await res.text();
+
+  t.equal(res.status, 400, "should return 400");
+  t.ok(
+    res.headers.get("content-type").includes("text/markdown"),
+    "should return markdown content type"
+  );
+  t.ok(body.includes("---"), "should have YAML frontmatter");
+
+  await store.close();
+});
+
+test("bun - returns JSON format when Accept: application/json", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+  const wrap = idempotency({ store, required: true });
+  const handler = wrap(async () => Response.json({ ok: true }));
+
+  const res = await handler(
+    new Request("http://localhost/test", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json"
+      },
+      body: JSON.stringify({})
+    })
+  );
+
+  const contentType = res.headers.get("content-type") || "";
+  const isJson =
+    contentType.includes("application/json") ||
+    contentType.includes("application/problem+json");
+  const body = isJson ? await res.json() : await res.text();
+
+  t.equal(res.status, 400, "should return 400");
+  t.ok(
+    contentType.includes("application/json"),
+    "should return JSON content type"
+  );
+  t.ok(body.type, "should have type field in JSON body");
+
+  await store.close();
+});
+
+runAdapterTests({
+  name: "bun",
+  setup: async () => {
+    /** @type {Map<string, (req: Request) => Promise<Response>>} */
+    const routes = new Map();
+
+    return {
+      mount: (method, path, middleware, handler) => {
+        const bunHandler = middleware(async (req) => {
+          const contentType = req.headers.get("content-type") || "";
+          let body;
+          if (contentType.includes("application/json")) {
+            try {
+              body = await req.json();
+            } catch {
+              body = undefined;
+            }
+          } else {
+            try {
+              body = await req.text();
+            } catch {
+              body = undefined;
+            }
+          }
+
+          const reqLike = { body };
+
+          return new Promise((resolve) => {
+            const res = {
+              send: (data) => {
+                if (typeof data === "string") {
+                  resolve(new Response(data));
+                } else {
+                  resolve(Response.json(data));
+                }
+              }
+            };
+            Promise.resolve(handler(reqLike, res)).catch((err) => {
+              resolve(
+                new Response(JSON.stringify({ error: String(err) }), {
+                  status: 500,
+                  headers: { "Content-Type": "application/json" }
+                })
+              );
+            });
+          });
+        });
+
+        routes.set(`${method.toUpperCase()}:${path}`, bunHandler);
+      },
+
+      request: async (options) => {
+        const routeHandler = routes.get(
+          `${options.method.toUpperCase()}:${options.path}`
+        );
+        const url = new URL(options.path, "http://localhost");
+        const headers = new Headers(options.headers || {});
+
+        if (options.body && typeof options.body === "object") {
+          headers.set("content-type", "application/json");
+        }
+
+        const req = new Request(url.toString(), {
+          method: options.method,
+          headers,
+          body: options.body
+            ? typeof options.body === "string"
+              ? options.body
+              : JSON.stringify(options.body)
+            : undefined
+        });
+
+        const response = await routeHandler(req);
+
+        const contentType = response.headers.get("content-type") || "";
+        let body;
+        if (contentType.includes("json")) {
+          try {
+            body = await response.json();
+          } catch {
+            body = await response.text();
+          }
+        } else {
+          const text = await response.text();
+          body = text || undefined;
+        }
+
+        return {
+          status: response.status,
+          headers: Object.fromEntries(response.headers.entries()),
+          body
+        };
+      },
+
+      teardown: async () => {
+        routes.clear();
+      }
+    };
+  },
+  createMiddleware: (options) => idempotency(options),
+  createStore: () => new SqliteIdempotencyStore({ path: ":memory:" })
+});

--- a/packages/frameworks/bun/index.js
+++ b/packages/frameworks/bun/index.js
@@ -1,0 +1,240 @@
+/**
+ * @typedef {import("@idempot/core").IdempotencyStore} IdempotencyStore
+ * @typedef {import("@idempot/core").ResilienceOptions} ResilienceOptions
+ * @typedef {import("@idempot/core").IdempotencyOptions} IdempotencyOptions
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  generateFingerprint,
+  validateExcludeFields,
+  validateIdempotencyKey,
+  validateIdempotencyOptions,
+  checkLookupConflicts,
+  shouldProcessRequest,
+  getCachedResponse,
+  prepareCachedResponse,
+  withResilience,
+  defaultOptions,
+  conflictErrorResponse,
+  keyValidationErrorResponse,
+  missingKeyResponse,
+  storeUnavailableResponse,
+  selectResponseFormat,
+  formatAsMarkdown
+} from "@idempot/core";
+
+/**
+ * HTTP header name for idempotency key as defined in
+ * https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07
+ * @constant
+ * @type {string}
+ */
+const HEADER_NAME = "idempotency-key";
+
+/**
+ * @typedef {(req: Request) => Response | Promise<Response>} BunHandler
+ */
+
+/**
+ * Build an error Response in the appropriate format based on the Accept header
+ * @param {string} acceptHeader - Value of the Accept request header
+ * @param {number} status - HTTP status code
+ * @param {Object} problem - RFC 9457 problem details
+ * @returns {Response}
+ */
+const buildErrorResponse = (acceptHeader, status, problem) => {
+  const format = selectResponseFormat(acceptHeader);
+
+  if (format === "text/markdown") {
+    return new Response(formatAsMarkdown(problem), {
+      status,
+      headers: { "Content-Type": "text/markdown; charset=utf-8" }
+    });
+  }
+
+  const contentType =
+    format === "application/problem+json"
+      ? "application/problem+json"
+      : "application/json";
+
+  return Response.json(problem, {
+    status,
+    headers: { "Content-Type": `${contentType}; charset=utf-8` }
+  });
+};
+
+const generateInstanceId = () => {
+  return `urn:uuid:${randomUUID()}`;
+};
+
+/**
+ * Create an idempotency wrapper for Bun `Request => Response` handlers.
+ *
+ * Returns a function that wraps a handler with idempotency enforcement.
+ * The returned wrapper has a `circuit` property for circuit-breaker monitoring.
+ *
+ * @example
+ * const withIdempotency = idempotency({ store });
+ * Bun.serve({
+ *   routes: {
+ *     "/orders": withIdempotency(async (req) => Response.json({ id: "1" }, { status: 201 })),
+ *   }
+ * });
+ *
+ * @param {Object} [options] - Idempotency options
+ * @param {IdempotencyStore} options.store - Storage backend
+ * @param {number} [options.maxKeyLength=255] - Maximum key length
+ * @param {number} [options.minKeyLength=21] - Minimum key length (default: 21 for nanoid)
+ * @returns {((handler: BunHandler) => BunHandler) & { circuit: import("opossum").CircuitBreaker | null }}
+ */
+export const idempotency = (options = {}) => {
+  const opts = { ...defaultOptions, ...options };
+  if (!opts.store) {
+    throw new Error(
+      "IdempotencyStore must be provided. " +
+        "Use SqliteIdempotencyStore({ path: ':memory:' }) for development"
+    );
+  }
+  validateExcludeFields(opts.excludeFields);
+  validateIdempotencyOptions(opts);
+  const { minKeyLength, maxKeyLength } = opts;
+  const { store: resilientStore, circuit } = withResilience(
+    opts.store,
+    opts.resilience
+  );
+
+  /**
+   * @param {BunHandler} handler
+   * @returns {BunHandler}
+   */
+  const wrap = (handler) => {
+    const wrappedHandler = async (/** @type {Request} */ req) => {
+      if (!shouldProcessRequest(req.method)) {
+        return handler(req);
+      }
+
+      const key = req.headers.get(HEADER_NAME) ?? undefined;
+      const instanceId = generateInstanceId();
+      const acceptHeader = req.headers.get("accept") ?? "";
+
+      if (key === undefined) {
+        if (opts.required) {
+          const problem = missingKeyResponse({
+            status: 400,
+            instance: instanceId
+          });
+          return buildErrorResponse(acceptHeader, 400, problem);
+        }
+        return handler(req);
+      }
+
+      const keyValidation = validateIdempotencyKey(key, {
+        minKeyLength,
+        maxKeyLength
+      });
+      if (!keyValidation.valid) {
+        const problem = keyValidationErrorResponse(
+          /** @type {string} */ (keyValidation.error),
+          {
+            status: 400,
+            instance: instanceId,
+            idempotencyKey: key
+          }
+        );
+        return buildErrorResponse(acceptHeader, 400, problem);
+      }
+
+      const bodyText = await req.text();
+      const fingerprint = await generateFingerprint(
+        bodyText,
+        opts.excludeFields
+      );
+
+      let lookup;
+      try {
+        lookup = await resilientStore.lookup(key, fingerprint);
+      } catch {
+        const problem = storeUnavailableResponse({
+          status: 503,
+          instance: instanceId
+        });
+        return buildErrorResponse(acceptHeader, 503, problem);
+      }
+
+      const conflict = checkLookupConflicts(lookup, key, fingerprint);
+      if (conflict.conflict) {
+        const problem = conflictErrorResponse(
+          /** @type {number} */ (conflict.status),
+          /** @type {string} */ (conflict.error),
+          {
+            instance: instanceId,
+            idempotencyKey: key
+          }
+        );
+        return buildErrorResponse(
+          acceptHeader,
+          /** @type {number} */ (conflict.status),
+          problem
+        );
+      }
+
+      const cached = getCachedResponse(lookup);
+      if (cached) {
+        const response = prepareCachedResponse(cached);
+        return new Response(response.body, {
+          status: response.status,
+          headers: response.headers
+        });
+      }
+
+      if (!lookup.byKey && !lookup.byFingerprint) {
+        try {
+          await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
+        } catch {
+          const problem = storeUnavailableResponse({
+            status: 503,
+            instance: instanceId
+          });
+          return buildErrorResponse(acceptHeader, 503, problem);
+        }
+
+        // Re-create the request so the handler can read the body again
+        const replayedReq = new Request(req.url, {
+          method: req.method,
+          headers: req.headers,
+          body: bodyText || undefined
+        });
+
+        const response = await handler(replayedReq);
+
+        const responseBody = await response.clone().text();
+        /** @type {Record<string, string>} */
+        const responseHeaders = {};
+        response.headers.forEach((value, headerKey) => {
+          responseHeaders[headerKey] = value;
+        });
+
+        try {
+          await resilientStore.complete(key, {
+            status: response.status,
+            headers: responseHeaders,
+            body: responseBody
+          });
+        } catch (err) {
+          console.error("Failed to cache response:", err);
+        }
+
+        return response;
+      }
+
+      return handler(req);
+    };
+
+    return wrappedHandler;
+  };
+
+  wrap.circuit = circuit;
+
+  return wrap;
+};

--- a/packages/frameworks/bun/jsr.json
+++ b/packages/frameworks/bun/jsr.json
@@ -1,0 +1,8 @@
+{
+  "name": "@idempot/bun-handler",
+  "version": "1.0.0",
+  "exports": "./index.js",
+  "publish": {
+    "include": ["LICENSE", "README.md", "index.js"]
+  }
+}

--- a/packages/frameworks/bun/package.json
+++ b/packages/frameworks/bun/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@idempot/bun-handler",
+  "version": "1.0.0",
+  "description": "Bun.serve handler wrapper for idempotency",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "bun",
+    "handler",
+    "idempotency",
+    "idempotent",
+    "ietf"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/idempot-dev/idempot-js.git"
+  },
+  "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "tap bun-handler.test.js"
+  },
+  "dependencies": {
+    "@idempot/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@idempot/sqlite-store": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,16 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
 
+  packages/frameworks/bun:
+    dependencies:
+      '@idempot/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@idempot/sqlite-store':
+        specifier: workspace:*
+        version: link:../../stores/sqlite
+
   packages/frameworks/express:
     dependencies:
       '@idempot/core':


### PR DESCRIPTION
This will add support for [`Bun.serve`](https://bun.com/docs/runtime/http/server) by providing a wrapper for the request/response route handling expected by Bun.

The added `bun-handler` package exports an `idempotency` function that takes a `store` similarly to other framework packages and returns a `withIdempotency` wrapper. This wrapper can then be used for defining the route handlers in the main `Bun.serve` configuration:

```js
import { idempotency } from "@idempot/bun-handler";
import { BunSqlIdempotencyStore } from "@idempot/bun-sql-store";

const store = new BunSqlIdempotencyStore("sqlite://:memory:");
const withIdempotency = idempotency({ store });

Bun.serve({
  routes: {
    "/orders": withIdempotency(async (req) => {
      const body = await req.json();
      const orderId = crypto.randomUUID();
      return Response.json({ id: orderId, ...body }, { status: 201 });
    }),
  },
});
```