### PR TITLE
docs(contributing): add Quality Assurance section with all quality gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,62 @@
 # Contributing
 
+## Quality Assurance
+
+This project maintains high code quality through automated checks that run on every commit and every PR.
+
+### Automatic Checks
+
+**Pre-commit hook** — runs automatically on every `git commit`:
+
+- `lint-staged` formats and lints staged files (ESLint + Prettier)
+- Coverage verification if source/test/config files changed
+- Commit message validation via commitlint
+
+### Local Quality Commands
+
+Run these before committing:
+
+| Command                         | Purpose                                           |
+| ------------------------------- | ------------------------------------------------- |
+| `pnpm run check`                | Lint + format check                               |
+| `pnpm run lint`                 | ESLint only                                       |
+| `pnpm run format:check`         | Prettier check only                               |
+| `pnpm run test`                 | Unit tests                                        |
+| `pnpm run test:verify-coverage` | **Verify 100% coverage** (required before commit) |
+| `pnpm run test:coverage`        | Detailed coverage report                          |
+| `pnpm run test:spec`            | Spec tests (Cucumber)                             |
+| `pnpm run test:integration`     | Integration tests                                 |
+| `pnpm run test:bun`             | Bun runtime tests                                 |
+| `pnpm run test:deno`            | Deno runtime tests                                |
+
+### Coverage Requirements
+
+**100% coverage is required** — all statements, branches, functions, and lines must be covered.
+
+```bash
+# Verify coverage before committing
+pnpm run test:verify-coverage
+
+# Debug uncovered lines
+pnpm run test:coverage
+```
+
+### CI (GitHub Actions)
+
+Every PR runs the same checks as local:
+
+- Lint + Prettier
+- Commit message validation
+- Dead code detection
+- Spec consistency with website
+- Tests on Node 22, 24 with coverage verification
+- Bun runtime tests
+- Deno runtime tests
+- Spec compliance tests (Cucumber)
+- Workflow validation
+
+---
+
 ## Running Integration Tests Locally
 
 This section covers how to run integration tests on your Mac for local development.
@@ -24,37 +81,23 @@ container system start
 3. Start the development containers:
 
 ```bash
-npm run test:container:start
+pnpm run test:container:start
 ```
 
 This starts Redis (port 6379) and Postgres (port 5432) in a lightweight VM.
-
-### Running Tests
-
-Run the integration tests:
-
-```bash
-npm run test:integration
-```
-
-Or run the full test suite with container management:
-
-```bash
-npm run test:container:start && npm run test:integration && npm run test:container:stop
-```
 
 ### Cleanup
 
 Stop and remove the containers:
 
 ```bash
-npm run test:container:stop
+pnpm run test:container:stop
 ```
 
 ### Troubleshooting
 
-- Check container status: `npm run test:container:status`
-- View container logs: `npm run test:container:logs`
-- Restart containers: `npm run test:container:restart`
+- Check container status: `pnpm run test:container:status`
+- View container logs: `pnpm run test:container:logs`
+- Restart containers: `pnpm run test:container:restart`
 
 For more apple/container commands, see the [apple/container documentation](https://apple.github.io/container/documentation/).


### PR DESCRIPTION
## Summary

- Added "Quality Assurance" section to CONTRIBUTING.md documenting all quality gates
- Covers pre-commit hooks, local quality commands, coverage requirements, and CI checks
- Removed redundant "### Running Tests" subsection that is now covered by the quality table
- Updated container commands to use `pnpm run` instead of `npm run`