### PR TITLE
Support TypeScript

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build type declarations
+        run: pnpm run build
       - name: Configure git for semantic-release
         run: |
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git

--- a/README.md
+++ b/README.md
@@ -11,28 +11,14 @@ Idempotency middleware for Hono, Express, and Fastify.
 
 ## TypeScript Support
 
-This library uses JavaScript with JSDoc comments for type information. Enable `allowJs` in your TypeScript configuration to use these types directly—no separate .d.ts files needed.
+This library uses JavaScript with JSDoc comments for type information. Each package ships `.d.ts` declaration files generated from the JSDoc-annotated source.
+TypeScript picks them up automatically via the `types` field in each `package.json`.
 
-To use this library in a TypeScript project:
+```typescript
+import { idempotency } from "@idempot/hono-middleware";
+```
 
-1. Add these settings to your `tsconfig.json`:
-
-   ```json
-   {
-     "allowJs": true,
-     "checkJs": true
-   }
-   ```
-
-2. Import the library as you normally would:
-
-   ```typescript
-   import { idempotency } from "@idempot/express-middleware";
-   ```
-
-3. JSDoc comments provide full type safety: parameter types, return types, and detailed documentation in your IDE.
-
-This approach simplifies maintenance while giving TypeScript users an excellent developer experience.
+The declarations are generated at publish time to ensure types match the published version.
 
 ## Supported Runtimes, Frameworks, and Stores
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -198,25 +198,11 @@ idempotency({
 
 ## TypeScript Support
 
-This library uses JavaScript with JSDoc comments for type information. Enable `allowJs` in your TypeScript configuration to use these types directly—no separate .d.ts files needed.
+This library uses JavaScript with JSDoc comments for type information. Each package ships `.d.ts` declaration files generated from the JSDoc-annotated source.
+TypeScript picks them up automatically via the `types` field in each `package.json`.
 
-To use this library in a TypeScript project:
+```typescript
+import { idempotency } from "@idempot/hono-middleware";
+```
 
-1. Add these settings to your `tsconfig.json`:
-
-   ```json
-   {
-     "allowJs": true,
-     "checkJs": true
-   }
-   ```
-
-2. Import the library as you normally would:
-
-   ```typescript
-   import { idempotency } from "@idempot/core";
-   ```
-
-3. JSDoc comments provide full type safety: parameter types, return types, and detailed documentation in your IDE.
-
-This approach simplifies maintenance while giving TypeScript users an excellent developer experience.
+The declarations are generated at publish time to ensure types match the published version.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "semantic-release": "^25.0.0",
     "sinon": "^21.0.0",
     "tap": "^21.5.0",
+    "typescript": "^6.0.2",
     "ulid": "^3.0.2",
     "vitepress": "^1.6.4"
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,28 +26,14 @@ Framework adapters and storage backends depend on this package for:
 
 ## TypeScript Support
 
-This library uses JavaScript with JSDoc comments for type information. Enable `allowJs` in your TypeScript configuration to use these types directly—no separate .d.ts files needed.
+This library uses JavaScript with JSDoc comments for type information. Each package ships `.d.ts` declaration files generated from the JSDoc-annotated source.
+TypeScript picks them up automatically via the `types` field in each `package.json`.
 
-To use this library in a TypeScript project:
+```typescript
+import { idempotency } from "@idempot/core";
+```
 
-1. Add these settings to your `tsconfig.json`:
-
-   ```json
-   {
-     "allowJs": true,
-     "checkJs": true
-   }
-   ```
-
-2. Import the library as you normally would:
-
-   ```typescript
-   import { idempotency } from "@idempot/core";
-   ```
-
-3. JSDoc comments provide full type safety: parameter types, return types, and detailed documentation in your IDE.
-
-This approach simplifies maintenance while giving TypeScript users an excellent developer experience.
+The declarations are generated at publish time to ensure types match the published version.
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,14 +4,16 @@
   "description": "Core idempotency logic for idempot middleware",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./src/index.js"
     }
   },
   "files": [
     "src",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap tests/"
   },
   "dependencies": {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "declarationDir": "types"
+  },
+  "include": ["src"]
+}

--- a/packages/frameworks/bun/package.json
+++ b/packages/frameworks/bun/package.json
@@ -4,14 +4,16 @@
   "description": "Bun.serve handler wrapper for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap bun-handler.test.js"
   },
   "dependencies": {

--- a/packages/frameworks/bun/tsconfig.json
+++ b/packages/frameworks/bun/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/frameworks/express/package.json
+++ b/packages/frameworks/express/package.json
@@ -4,14 +4,16 @@
   "description": "Express middleware for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap express-middleware.test.js"
   },
   "peerDependencies": {

--- a/packages/frameworks/express/tsconfig.json
+++ b/packages/frameworks/express/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/frameworks/fastify/package.json
+++ b/packages/frameworks/fastify/package.json
@@ -4,14 +4,16 @@
   "description": "Fastify middleware for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap fastify-middleware.test.js"
   },
   "peerDependencies": {

--- a/packages/frameworks/fastify/tsconfig.json
+++ b/packages/frameworks/fastify/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/frameworks/hono/package.json
+++ b/packages/frameworks/hono/package.json
@@ -4,14 +4,16 @@
   "description": "Hono middleware for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap hono-middleware.test.js"
   },
   "peerDependencies": {

--- a/packages/frameworks/hono/tsconfig.json
+++ b/packages/frameworks/hono/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/stores/bun-sql/package.json
+++ b/packages/stores/bun-sql/package.json
@@ -4,14 +4,16 @@
   "description": "Bun SQL storage backend for idempotency (SQLite, PostgreSQL, MySQL)",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -34,6 +36,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "echo 'Tests are in tests/runtime/bun/ - run: npm run test:bun' && exit 0"
   },
   "dependencies": {

--- a/packages/stores/bun-sql/tsconfig.json
+++ b/packages/stores/bun-sql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/stores/mysql/package.json
+++ b/packages/stores/mysql/package.json
@@ -4,16 +4,21 @@
   "description": "MySQL storage backend for idempotency",
   "type": "module",
   "main": "./node-mysql.js",
+  "types": "./types/node-mysql.d.ts",
   "exports": {
     ".": {
+      "types": "./types/node-mysql.d.ts",
       "import": "./node-mysql.js"
     },
-    "./deno-mysql.js": "./deno-mysql.js"
+    "./deno-mysql.js": {
+      "types": "./types/deno-mysql.d.ts",
+      "import": "./deno-mysql.js"
+    }
   },
   "files": [
     "node-mysql.js",
     "deno-mysql.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -32,6 +37,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap tests/"
   },
   "peerDependencies": {

--- a/packages/stores/mysql/tsconfig.json
+++ b/packages/stores/mysql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["node-mysql.js", "deno-mysql.js"]
+}

--- a/packages/stores/postgres/package.json
+++ b/packages/stores/postgres/package.json
@@ -4,14 +4,16 @@
   "description": "PostgreSQL storage backend for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap tests/"
   },
   "peerDependencies": {

--- a/packages/stores/postgres/tsconfig.json
+++ b/packages/stores/postgres/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/packages/stores/redis/package.json
+++ b/packages/stores/redis/package.json
@@ -4,16 +4,21 @@
   "description": "Redis storage backend for idempotency",
   "type": "module",
   "main": "./node-redis.js",
+  "types": "./types/node-redis.d.ts",
   "exports": {
     ".": {
+      "types": "./types/node-redis.d.ts",
       "import": "./node-redis.js"
     },
-    "./deno-redis.js": "./deno-redis.js"
+    "./deno-redis.js": {
+      "types": "./types/deno-redis.d.ts",
+      "import": "./deno-redis.js"
+    }
   },
   "files": [
     "node-redis.js",
     "deno-redis.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -32,6 +37,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap tests/"
   },
   "peerDependencies": {

--- a/packages/stores/redis/tsconfig.json
+++ b/packages/stores/redis/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["node-redis.js", "deno-redis.js"]
+}

--- a/packages/stores/sqlite/package.json
+++ b/packages/stores/sqlite/package.json
@@ -4,15 +4,17 @@
   "description": "SQLite storage backend for idempotency",
   "type": "module",
   "main": "./index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.js"
     }
   },
   "files": [
     "index.js",
     "deno-sqlite.js",
-    "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -31,6 +33,8 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tap tests/"
   },
   "peerDependencies": {

--- a/packages/stores/sqlite/tsconfig.json
+++ b/packages/stores/sqlite/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declarationDir": "types"
+  },
+  "include": ["index.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.4.1
-        version: 20.4.3(@types/node@20.19.37)(typescript@5.9.3)
+        version: 20.4.3(@types/node@20.19.37)(typescript@6.0.2)
       '@commitlint/config-conventional':
         specifier: ^20.4.1
         version: 20.4.3
@@ -35,10 +35,10 @@ importers:
         version: 1.19.11(hono@4.12.7)
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
+        version: 10.0.1(semantic-release@25.0.3(typescript@6.0.2))
       '@semantic-release/npm':
         specifier: ^13.1.5
-        version: 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
+        version: 13.1.5(semantic-release@25.0.3(typescript@6.0.2))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -77,7 +77,7 @@ importers:
         version: 16.4.0
       multi-semantic-release:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.9.3)
+        version: 3.1.0(typescript@6.0.2)
       mysql2:
         specifier: ^3.20.0
         version: 3.20.0(@types/node@20.19.37)
@@ -89,19 +89,22 @@ importers:
         version: 3.8.1
       semantic-release:
         specifier: ^25.0.0
-        version: 25.0.3(typescript@5.9.3)
+        version: 25.0.3(typescript@6.0.2)
       sinon:
         specifier: ^21.0.0
         version: 21.0.3
       tap:
         specifier: ^21.5.0
-        version: 21.6.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 21.6.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
       ulid:
         specifier: ^3.0.2
         version: 3.0.2
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.50.0)(@types/node@20.19.37)(postcss@8.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.50.0)(@types/node@20.19.37)(postcss@8.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@6.0.2)
 
   packages/core:
     dependencies:
@@ -4512,6 +4515,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -4987,11 +4995,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@20.4.3(@types/node@20.19.37)(typescript@5.9.3)':
+  '@commitlint/cli@20.4.3(@types/node@20.19.37)(typescript@6.0.2)':
     dependencies:
       '@commitlint/format': 20.4.3
       '@commitlint/lint': 20.4.3
-      '@commitlint/load': 20.4.3(@types/node@20.19.37)(typescript@5.9.3)
+      '@commitlint/load': 20.4.3(@types/node@20.19.37)(typescript@6.0.2)
       '@commitlint/read': 20.4.3
       '@commitlint/types': 20.4.3
       tinyexec: 1.0.2
@@ -5038,14 +5046,14 @@ snapshots:
       '@commitlint/rules': 20.4.3
       '@commitlint/types': 20.4.3
 
-  '@commitlint/load@20.4.3(@types/node@20.19.37)(typescript@5.9.3)':
+  '@commitlint/load@20.4.3(@types/node@20.19.37)(typescript@6.0.2)':
     dependencies:
       '@commitlint/config-validator': 20.4.3
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.4.3
       '@commitlint/types': 20.4.3
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@20.19.37)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.2)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@20.19.37)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -5423,6 +5431,22 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
 
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@20.19.37)(typescript@6.0.2)':
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node14': 14.1.8
+      '@tsconfig/node16': 16.1.8
+      '@tsconfig/node18': 18.2.6
+      '@tsconfig/node20': 20.1.9
+      '@types/node': 20.19.37
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.2
+      v8-compile-cache-lib: 3.0.1
+
   '@isaacs/which@7.0.4':
     dependencies:
       isexe: 4.0.0
@@ -5691,7 +5715,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.0
       conventional-changelog-writer: 8.4.0
@@ -5701,7 +5725,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.17.23
       micromatch: 4.0.8
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5709,7 +5733,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -5719,11 +5743,11 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.6(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/github@12.0.6(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -5739,14 +5763,14 @@ snapshots:
       lodash-es: 4.17.23
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
       tinyglobby: 0.2.15
       undici: 7.24.6
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       '@actions/core': 3.0.0
       '@semantic-release/error': 4.0.0
@@ -5761,11 +5785,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
       semver: 7.7.4
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.0
       conventional-changelog-writer: 8.4.0
@@ -5777,7 +5801,7 @@ snapshots:
       into-stream: 7.0.0
       lodash-es: 4.17.23
       read-package-up: 11.0.0
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6117,6 +6141,16 @@ snapshots:
       - '@types/node'
       - typescript
 
+  '@tapjs/typescript@3.5.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.37)(typescript@6.0.2)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@20.19.37)(typescript@6.0.2)
+      '@tapjs/core': 4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
   '@tapjs/worker@4.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@tapjs/core': 4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6214,10 +6248,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.37))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.37))(vue@3.5.31(typescript@6.0.2))':
     dependencies:
       vite: 5.4.21(@types/node@20.19.37)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.31(typescript@6.0.2)
 
   '@vue/compiler-core@3.5.31':
     dependencies:
@@ -6283,28 +6317,28 @@ snapshots:
       '@vue/shared': 3.5.31
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.31(vue@3.5.31(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.31(vue@3.5.31(typescript@6.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.31
       '@vue/shared': 3.5.31
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.31(typescript@6.0.2)
 
   '@vue/shared@3.5.31': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vueuse/core@12.8.2(typescript@6.0.2)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.2)
+      vue: 3.5.31(typescript@6.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@6.0.2)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.31(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.2)
+      '@vueuse/shared': 12.8.2(typescript@6.0.2)
+      vue: 3.5.31(typescript@6.0.2)
     optionalDependencies:
       focus-trap: 7.8.0
     transitivePeerDependencies:
@@ -6312,9 +6346,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@12.8.2(typescript@6.0.2)':
     dependencies:
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.31(typescript@6.0.2)
     transitivePeerDependencies:
       - typescript
 
@@ -6738,12 +6772,12 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@20.19.37)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@20.19.37)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
       '@types/node': 20.19.37
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.2)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -6753,14 +6787,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8077,7 +8111,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multi-semantic-release@3.1.0(typescript@5.9.3):
+  multi-semantic-release@3.1.0(typescript@6.0.2):
     dependencies:
       '@manypkg/get-packages': 1.1.3
       blork: 9.3.0
@@ -8092,7 +8126,7 @@ snapshots:
       lodash: 4.17.21
       meow: 8.1.2
       promise-events: 0.2.4
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.3(typescript@6.0.2)
       semver: 7.7.4
       signale: 1.4.0
       stream-buffers: 3.0.3
@@ -8884,15 +8918,15 @@ snapshots:
 
   seed-random@2.2.0: {}
 
-  semantic-release@25.0.3(typescript@5.9.3):
+  semantic-release@25.0.3(typescript@6.0.2):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@6.0.2))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.6(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/github': 12.0.6(semantic-release@25.0.3(typescript@6.0.2))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@6.0.2))
+      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.3(typescript@6.0.2))
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.2)
       debug: 4.4.3(supports-color@8.1.1)
       env-ci: 11.2.0
       execa: 9.6.1
@@ -9256,7 +9290,7 @@ snapshots:
       yaml: 2.8.2
       yaml-types: 0.4.0(yaml@2.8.2)
 
-  tap@21.6.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  tap@21.6.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2):
     dependencies:
       '@tapjs/after': 3.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/after-each': 4.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -9275,7 +9309,7 @@ snapshots:
       '@tapjs/spawn': 4.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/stdin': 4.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/test': 4.4.2(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tapjs/typescript': 3.5.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.37)(typescript@5.9.3)
+      '@tapjs/typescript': 3.5.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.37)(typescript@6.0.2)
       '@tapjs/worker': 4.3.4(@tapjs/core@4.5.2(@types/node@20.19.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       resolve-import: 2.4.0
     transitivePeerDependencies:
@@ -9454,6 +9488,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.2: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -9572,7 +9608,7 @@ snapshots:
       '@types/node': 20.19.37
       fsevents: 2.3.3
 
-  vitepress@1.6.4(@algolia/client-search@5.50.0)(@types/node@20.19.37)(postcss@8.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.50.0)(@types/node@20.19.37)(postcss@8.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@6.0.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
@@ -9581,17 +9617,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@20.19.37))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@20.19.37))(vue@3.5.31(typescript@6.0.2))
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.31
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.2)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(typescript@6.0.2)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.21(@types/node@20.19.37)
-      vue: 3.5.31(typescript@5.9.3)
+      vue: 3.5.31(typescript@6.0.2)
     optionalDependencies:
       postcss: 8.5.8
     transitivePeerDependencies:
@@ -9621,15 +9657,15 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vue@3.5.31(typescript@5.9.3):
+  vue@3.5.31(typescript@6.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.31
       '@vue/compiler-sfc': 3.5.31
       '@vue/runtime-dom': 3.5.31
-      '@vue/server-renderer': 3.5.31(vue@3.5.31(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.31(vue@3.5.31(typescript@6.0.2))
       '@vue/shared': 3.5.31
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   walk-up-path@4.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strict": false
+  }
+}


### PR DESCRIPTION
The JsDoc types are not available to library consumers (e.g. via NPM) with the current release workflow, since `allowJs` and `checkJs` only affect files _within_ the project and not for third-party dependencies. 

This PR will therefore generate and ship `.d.ts` files. Since the source is already beatifully JSDoc-annotated, it is possible to generate the `.d.ts` files at the time of release. This will therefore not touch the existing implementation of the package while benefitting client consumers in TypeScript a lot. 😄 

---

The JsDoc types are not available to library consumers (e.g. via NPM) with the current release workflow, since `allowJs` and `checkJs` only affect files _within_ the project and not files in third-party dependencies. TypeScript never type-checks or reads JSDoc from JS files inside `node_modules` regardless of those two settings.

For packages in `node_modules`, TypeScript looks for:
1. A `.d.ts` file referenced by the `types`/`typings` field in `package.json`
2. An `index.d.ts` alongside the entry point
3. A package in `@types/`

The packages currently have none of these, so TypeScript falls back to `any` for package consumers (verified in a simple example project which pulls `@idempot` from NPM). 

The instructions in the README would only work if you pointed TypeScript directly at the source files (e.g., via `paths` aliasing in `tsconfig.json`) which bypass `node_modules` entirely. This doesn't seem like a realistic setup for most consumers IMO. 😄 

---

This does have the unfortunate side effect of filling the packages with `tsconfig.json` files. I chose this approach since it keep the actual release mechanism simple (given that it's critical), while sacrificing the simplicity of each package slightly. 

It is very possible to make the type generation at release more complex (and more risky), but that would keep the package implementation slightly more clean. Let me know which (if any) you prefer. 😄 