### PR TITLE
chore: configure semantic-release to use pnpm as npm client

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+  "npmClient": "pnpm"
+}


### PR DESCRIPTION
## Summary
Resolves the release workflow failure caused by the TypeScript declarations PR (#80).

The error was:
```
npm error Unsupported URL Type "workspace:": workspace:*
```

When semantic-release runs `npm version` inside each package to bump versions, it uses `npm` directly which doesn't understand pnpm's `workspace:*` protocol.

## Fix
Add `.releaserc` file setting `npmClient: pnpm` to tell semantic-release to use pnpm instead of npm for version bumping.

## Testing
This fix needs to be merged to trigger the release workflow.