### PR TITLE
chore: pass npmClient config to semantic-release via environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
-        run: pnpm exec multi-semantic-release
+        run: NPM_CONFIG_NPMCLIENT=pnpm pnpm exec multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes the release workflow failure.

The previous `.releaserc` with `npmClient: pnpm` wasn't being picked up properly. This uses the `NPM_CONFIG_NPMCLIENT=pnpm` environment variable instead, which is more reliable.

This is a chore commit - doesn't trigger a release.