### PR TITLE
chore: disable workspaces-update in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+workspaces-update=false


### PR DESCRIPTION
## Summary
Fixes the release workflow failure caused by pnpm workspace: protocol in dependencies.

When semantic-release runs `npm version` to bump versions, npm attempts to process workspaces which fails with `EUNSUPPORTEDPROTOCOL` error for pnpm workspace: protocol.

## Fix
Adding `workspaces-update=false` to `.npmrc` prevents npm from processing workspaces during version bumping.

This is a chore commit - doesn't trigger a release.