### PR TITLE
chore: remove non-functional .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,3 +1,0 @@
-{
-  "npmClient": "pnpm"
-}


### PR DESCRIPTION
## Summary
Removes the `.releaserc` file that was added in #83 as a failed fix attempt.

The `.releaserc` with `npmClient: pnpm` didn't fix the `EUNSUPPORTEDPROTOCOL` error. The working fix is `workspaces-update=false` in `.npmrc` which is already in #85.

This is a chore commit - doesn't trigger a release.