### PR TITLE
Simplify the TypeScript definitions for Bun handlers

### DIFF
--- a/packages/frameworks/bun/index.js
+++ b/packages/frameworks/bun/index.js
@@ -33,10 +33,6 @@ import {
 const HEADER_NAME = "idempotency-key";
 
 /**
- * @typedef {(req: Request) => Response | Promise<Response>} BunHandler
- */
-
-/**
  * Build an error Response in the appropriate format based on the Accept header
  * @param {string} acceptHeader - Value of the Accept request header
  * @param {number} status - HTTP status code
@@ -86,7 +82,7 @@ const generateInstanceId = () => {
  * @param {IdempotencyStore} options.store - Storage backend
  * @param {number} [options.maxKeyLength=255] - Maximum key length
  * @param {number} [options.minKeyLength=21] - Minimum key length (default: 21 for nanoid)
- * @returns {((handler: BunHandler) => BunHandler) & { circuit: import("opossum").CircuitBreaker | null }}
+ * @returns {((handler: (req: Request) => Response | Promise<Response>) => (req: Request) => Response | Promise<Response>) & { circuit: import("opossum").CircuitBreaker | null }}
  */
 export const idempotency = (options = {}) => {
   const opts = { ...defaultOptions, ...options };
@@ -105,8 +101,8 @@ export const idempotency = (options = {}) => {
   );
 
   /**
-   * @param {BunHandler} handler
-   * @returns {BunHandler}
+   * @param {(req: Request) => Response | Promise<Response>} handler
+   * @returns {(req: Request) => Response | Promise<Response>}
    */
   const wrap = (handler) => {
     const wrappedHandler = async (/** @type {Request} */ req) => {


### PR DESCRIPTION
The `BunHandler` type alias of the Bun handler added in #78 hides useful information for library consumers. 
The `BunHandler` type isn't being expanded by most IDEs and therefore hides what the expected type is. This could create confusion and make the library harder to use than necessary: 

<img width="666" height="169" alt="image" src="https://github.com/user-attachments/assets/ad06b14e-9611-4a91-9e55-b2d8516cdbe9" />

---

This PR makes the expectation of a simple `Request => Response` function transparent by removing the `BunHandler` type alias and should hopefully make adopting the library easier for TypeScript consumers.