### PR TITLE
fix(stores): add LIMIT clause to DELETE statements in lookup functions

### DIFF
--- a/packages/stores/bun-sql/index.js
+++ b/packages/stores/bun-sql/index.js
@@ -31,12 +31,18 @@ export class BunSqlIdempotencyStore {
   isMySQL;
 
   /**
+   * @type {boolean}
+   */
+  isPostgres;
+
+  /**
    * @param {string} connectionString - Database connection string or path
    * @param {BunSqlIdempotencyStoreOptions} [options]
    */
   constructor(connectionString, options = {}) {
     this.isSqlite = this.isSqliteConnection(connectionString);
     this.isMySQL = this.isMySqlConnection(connectionString);
+    this.isPostgres = this.isPostgresConnection(connectionString);
 
     if (this.isSqlite) {
       const sqlitePath = this.normalizeSqlitePath(connectionString);
@@ -116,6 +122,17 @@ export class BunSqlIdempotencyStore {
     if (!connectionString) return false;
     const lower = connectionString.toLowerCase();
     return lower.includes("mysql") || lower.includes("mariadb");
+  }
+
+  /**
+   * Check if connection string is PostgreSQL
+   * @param {string} [connectionString]
+   * @returns {boolean}
+   */
+  isPostgresConnection(connectionString) {
+    if (!connectionString) return false;
+    const lower = connectionString.toLowerCase();
+    return lower.includes("postgres") || lower.includes("postgresql");
   }
 
   /**
@@ -261,8 +278,12 @@ export class BunSqlIdempotencyStore {
         byFingerprint: this.parseRecord(byFingerprintRow)
       };
     } else {
-      await this
-        .db`DELETE FROM idempotency_records WHERE expires_at <= ${Date.now()}`;
+      // PostgreSQL doesn't support LIMIT in DELETE, use subquery
+      const deleteSql = this.isPostgres
+        ? "DELETE FROM idempotency_records WHERE key IN (SELECT key FROM idempotency_records WHERE expires_at <= $1 LIMIT 10)"
+        : "DELETE FROM idempotency_records WHERE expires_at <= ? LIMIT 10";
+      const deleteParams = this.isPostgres ? [Date.now()] : [Date.now()];
+      await this.db.unsafe(deleteSql, deleteParams);
 
       const keyColumn = this.isMySQL ? "`key`" : '"key"';
       const paramPlaceholder = this.isMySQL ? "?" : "$1";

--- a/packages/stores/mysql/deno-mysql.js
+++ b/packages/stores/mysql/deno-mysql.js
@@ -126,7 +126,7 @@ export class MysqlIdempotencyStore {
    */
   async lookup(key, fingerprint) {
     await this.client.execute(
-      "DELETE FROM idempotency_records WHERE expires_at <= ?",
+      "DELETE FROM idempotency_records WHERE expires_at <= ? LIMIT 10",
       [Date.now()]
     );
 

--- a/packages/stores/mysql/node-mysql.js
+++ b/packages/stores/mysql/node-mysql.js
@@ -89,7 +89,7 @@ export class MysqlIdempotencyStore {
    */
   async lookup(key, fingerprint) {
     await this.pool.query(
-      `DELETE FROM \`${this.tableName}\` WHERE expires_at <= ?`,
+      `DELETE FROM \`${this.tableName}\` WHERE expires_at <= ? LIMIT 10`,
       [Date.now()]
     );
 

--- a/packages/stores/postgres/index.js
+++ b/packages/stores/postgres/index.js
@@ -113,8 +113,9 @@ export class PostgresIdempotencyStore {
    * @returns {Promise<{byKey: IdempotencyRecord | null, byFingerprint: IdempotencyRecord | null}>}
    */
   async lookup(key, fingerprint) {
+    // Use subquery with LIMIT since PostgreSQL doesn't support LIMIT in DELETE directly
     await this.pool.query(
-      `DELETE FROM ${this.quotedSchemaIdentifier}.idempotency_records WHERE expires_at <= $1`,
+      `DELETE FROM ${this.quotedSchemaIdentifier}.idempotency_records WHERE key IN (SELECT key FROM ${this.quotedSchemaIdentifier}.idempotency_records WHERE expires_at <= $1 LIMIT 10)`,
       [Date.now()]
     );
 


### PR DESCRIPTION
Add LIMIT 10 to the DELETE statements that remove expired records in all SQL store implementations. This prevents the lookup function from taking a long time when there are many expired records to clean up.

## Changes
- PostgreSQL: DELETE ... WHERE key IN (SELECT key ... LIMIT 10) - uses subquery since PostgreSQL doesn't support LIMIT in DELETE directly
- MySQL (Node): DELETE ... LIMIT 10
- MySQL (Deno): DELETE ... LIMIT 10
- Bun SQL: Uses PostgreSQL subquery syntax for PostgreSQL connections, direct LIMIT for MySQL/SQLite

## Notes
- SQLite already had LIMIT 10 implemented
- All unit tests and integration tests pass
- The LIMIT ensures cleanup operations don't block lookup requests when there are many expired records
- This fixes an oversight where DELETE statements could scan and delete unbounded numbers of expired records