### PR TITLE
fix(deps): declare unlisted devDependencies in workspace packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,5 +41,8 @@
     "jsonpath-plus": "^10.3.0",
     "opossum": "^9.0.0",
     "xxhash-wasm": "^1.1.0"
+  },
+  "devDependencies": {
+    "fast-check": "^4.6.0"
   }
 }

--- a/packages/frameworks/bun/package.json
+++ b/packages/frameworks/bun/package.json
@@ -41,6 +41,7 @@
     "@idempot/core": "workspace:*"
   },
   "devDependencies": {
-    "@idempot/sqlite-store": "workspace:*"
+    "@idempot/sqlite-store": "workspace:*",
+    "opossum": "^9.0.0"
   }
 }

--- a/packages/stores/mysql/package.json
+++ b/packages/stores/mysql/package.json
@@ -46,5 +46,8 @@
   },
   "dependencies": {
     "@idempot/core": "workspace:*"
+  },
+  "devDependencies": {
+    "sinon": "^21.0.0"
   }
 }

--- a/packages/stores/postgres/package.json
+++ b/packages/stores/postgres/package.json
@@ -42,5 +42,8 @@
   },
   "dependencies": {
     "@idempot/core": "workspace:*"
+  },
+  "devDependencies": {
+    "sinon": "^21.0.0"
   }
 }

--- a/packages/stores/redis/package.json
+++ b/packages/stores/redis/package.json
@@ -46,5 +46,9 @@
   },
   "dependencies": {
     "@idempot/core": "workspace:*"
+  },
+  "devDependencies": {
+    "fast-check": "^4.6.0",
+    "sinon": "^21.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,10 @@ importers:
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
+    devDependencies:
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
 
   packages/frameworks/bun:
     dependencies:
@@ -127,6 +131,9 @@ importers:
       '@idempot/sqlite-store':
         specifier: workspace:*
         version: link:../../stores/sqlite
+      opossum:
+        specifier: ^9.0.0
+        version: 9.0.0
 
   packages/frameworks/express:
     dependencies:
@@ -181,6 +188,10 @@ importers:
       mysql2:
         specifier: '>=3.0.0'
         version: 3.20.0(@types/node@20.19.37)
+    devDependencies:
+      sinon:
+        specifier: ^21.0.0
+        version: 21.0.3
 
   packages/stores/postgres:
     dependencies:
@@ -190,6 +201,10 @@ importers:
       pg:
         specifier: '>=8.0.0'
         version: 8.20.0
+    devDependencies:
+      sinon:
+        specifier: ^21.0.0
+        version: 21.0.3
 
   packages/stores/redis:
     dependencies:
@@ -199,6 +214,13 @@ importers:
       ioredis:
         specifier: '>=5.0.0'
         version: 5.10.0
+    devDependencies:
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
+      sinon:
+        specifier: ^21.0.0
+        version: 21.0.3
 
   packages/stores/sqlite:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the Fallow `dead-code` CI failure that causes PR #135 (and any branch) to fail the Fallow check.

## Problem

Fallow flagged three packages as **unlisted dependencies** because they were imported in workspace source files but only declared in the root `package.json` (or transitively via another workspace):

| Package | Used in | Was declared in |
|---|---|---|
| `fast-check` | `packages/core/tests/*.js`, `packages/stores/redis/*.test.js` | Root `package.json` only |
| `sinon` | `packages/stores/{mysql,postgres,redis}/tests/*.js` | Root `package.json` only |
| `opossum` | `packages/frameworks/bun/index.js` (JSDoc type import) | `packages/core/package.json` only |

## Changes

Added explicit `devDependencies` to each consuming workspace:

- **`packages/core/package.json`** → `fast-check: ^4.6.0`
- **`packages/stores/redis/package.json`** → `fast-check: ^4.6.0`, `sinon: ^21.0.0`
- **`packages/stores/mysql/package.json`** → `sinon: ^21.0.0`
- **`packages/stores/postgres/package.json`** → `sinon: ^21.0.0`
- **`packages/frameworks/bun/package.json`** → `opossum: ^9.0.0`

All versions already existed in the monorepo lockfile; `pnpm install` only updated workspace references.

## Verification

```bash
$ npx fallow dead-code --unlisted-deps
✓ No issues found
```

## Related

- Unblocks #135
- For pre-existing Fallow false positives, see #146
