### PR TITLE
fix(ci): remove invalid --include-mail=false arg from lychee link checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -40,7 +40,6 @@ jobs:
           args: |
             docs/.vitepress/dist
             --root-dir docs/.vitepress/dist
-            --include-mail=false
             --exclude "^file://"
             --accept '200..=299,403'
           # Don't fail action on broken links (we'll create an issue instead)


### PR DESCRIPTION
## Problem

The lychee link checker workflow has been creating a "Link Checker Report" issue on every single run since it was introduced.

## Root cause

`--include-mail=false` was passed as a CLI argument, but lychee v0.23.0's `--include-mail` flag is a bare boolean switch that does not accept a value. This caused lychee to exit with an error immediately, before checking any links.

Because the workflow sets `fail: false`, the step itself stayed green, but the real exit code was still emitted. The next step (`Create Issue From File`) has `if: steps.lychee.outputs.exit_code != 0`, so it fired on every run and opened an empty issue.

## Fix

Remove the invalid `--include-mail=false` argument. Lychee excludes email links by default anyway, so the argument was unnecessary.

## Issues closed

Closes #152 Closes #151 Closes #150 Closes #149 Closes #148 Closes #145 Closes #144 Closes #143 Closes #142 Closes #141 Closes #140 Closes #139 Closes #138 Closes #110 Closes #109 Closes #108 Closes #107 Closes #106 Closes #105 Closes #104 Closes #103 Closes #102 Closes #101 Closes #100 Closes #99 Closes #97 Closes #96 Closes #95 Closes #94 Closes #93 Closes #92