### PR TITLE
feat: add errorFormatter option for custom error response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ app.post("/orders", idempotency({ store }), async (c) => {
 
 The middleware accepts an options object with the following properties:
 
-| Option          | Type               | Default               | Description                                          |
-| --------------- | ------------------ | --------------------- | ---------------------------------------------------- |
-| `store`         | `IdempotencyStore` | required              | Storage backend (Redis, PostgreSQL, MySQL, SQLite)   |
-| `required`      | `boolean`          | `true`                | Whether the `Idempotency-Key` header is required     |
-| `ttlMs`         | `number`           | `86400000` (24 hours) | Time-to-live for idempotency records in milliseconds |
-| `minKeyLength`  | `number`           | `21`                  | Minimum length for idempotency keys                  |
-| `maxKeyLength`  | `number`           | `255`                 | Maximum length for idempotency keys                  |
-| `excludeFields` | `string[]`         | `[]`                  | Body fields to exclude from request fingerprint      |
-| `resilience`    | `object`           | see below             | Circuit breaker and retry configuration              |
+| Option           | Type               | Default               | Description                                                                                                                                |
+| ---------------- | ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `store`          | `IdempotencyStore` | required              | Storage backend (Redis, PostgreSQL, MySQL, SQLite)                                                                                         |
+| `required`       | `boolean`          | `true`                | Whether the `Idempotency-Key` header is required                                                                                           |
+| `ttlMs`          | `number`           | `86400000` (24 hours) | Time-to-live for idempotency records in milliseconds                                                                                       |
+| `minKeyLength`   | `number`           | `21`                  | Minimum length for idempotency keys                                                                                                        |
+| `maxKeyLength`   | `number`           | `255`                 | Maximum length for idempotency keys                                                                                                        |
+| `excludeFields`  | `string[]`         | `[]`                  | Body fields to exclude from request fingerprint                                                                                            |
+| `resilience`     | `object`           | see below             | Circuit breaker and retry configuration                                                                                                    |
+| `errorFormatter` | `Function`         | `undefined`           | Transform RFC 9457 problem details into a custom error response body. Only applied to JSON responses; markdown responses remain unchanged. |
 
 **Resilience options:**
 
@@ -158,6 +159,26 @@ app.post(
       timeoutMs: 1000,
       maxRetries: 5
     }
+  }),
+  handler
+);
+```
+
+**Custom error response format:**
+
+Use `errorFormatter` to make idempotency error responses match your API's existing error structure. The function receives the full RFC 9457 problem object and returns your custom response body. Only JSON responses are transformed; `text/markdown` responses continue to use the raw RFC 9457 fields.
+
+```javascript
+app.post(
+  "/orders",
+  idempotency({
+    store,
+    errorFormatter: (problem) => ({
+      error: problem.title,
+      message: problem.detail,
+      code: problem.status,
+      requestId: problem.instance
+    })
   }),
   handler
 );

--- a/docs/frameworks/bun.md
+++ b/docs/frameworks/bun.md
@@ -46,6 +46,7 @@ Creates a handler wrapper for idempotency enforcement.
 - `ttlMs`: Time-to-live for idempotency records in milliseconds
 - `excludeFields`: Fields to exclude from fingerprint calculation
 - `resilience`: Circuit breaker and retry options
+- `errorFormatter`: Function to transform RFC 9457 problem details into a custom error response body
 
 **Returns:** A function `(handler) => handler` that wraps a `Request => Response` handler. The returned wrapper function has a `circuit` property for circuit-breaker monitoring.
 

--- a/docs/frameworks/express.md
+++ b/docs/frameworks/express.md
@@ -44,5 +44,6 @@ Creates Express middleware for idempotency.
 - `ttlMs`: Time-to-live for idempotency records in milliseconds
 - `excludeFields`: Fields to exclude from fingerprint calculation
 - `resilience`: Circuit breaker and retry options
+- `errorFormatter`: Function to transform RFC 9457 problem details into a custom error response body
 
 **Returns:** Express middleware function with `circuit` property for monitoring.

--- a/docs/frameworks/fastify.md
+++ b/docs/frameworks/fastify.md
@@ -46,5 +46,6 @@ Creates Fastify preHandler hook for idempotency.
 - `ttlMs`: Time-to-live for idempotency records in milliseconds
 - `excludeFields`: Fields to exclude from fingerprint calculation
 - `resilience`: Circuit breaker and retry options
+- `errorFormatter`: Function to transform RFC 9457 problem details into a custom error response body
 
 **Returns:** Fastify preHandler hook function with `circuit` property for monitoring.

--- a/docs/frameworks/hono.md
+++ b/docs/frameworks/hono.md
@@ -42,5 +42,6 @@ Creates Hono middleware for idempotency.
 - `ttlMs`: Time-to-live for idempotency records in milliseconds
 - `excludeFields`: Fields to exclude from fingerprint calculation
 - `resilience`: Circuit breaker and retry options
+- `errorFormatter`: Function to transform RFC 9457 problem details into a custom error response body
 
 **Returns:** Hono middleware function with `circuit` property for monitoring.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -15,15 +15,16 @@ The library enforces sensible defaults that prioritize security and reliability.
 
 ### Core Options
 
-| Option          | Type               | Default               | Description                                                    |
-| --------------- | ------------------ | --------------------- | -------------------------------------------------------------- |
-| `store`         | `IdempotencyStore` | **required**          | Storage backend for persisting idempotency records             |
-| `required`      | `boolean`          | `true`                | Whether requests must include an `Idempotency-Key` header      |
-| `ttlMs`         | `number`           | `86400000` (24 hours) | Time-to-live in milliseconds for idempotency records           |
-| `minKeyLength`  | `number`           | `21`                  | Minimum allowed length for idempotency keys                    |
-| `maxKeyLength`  | `number`           | `255`                 | Maximum allowed length for idempotency keys                    |
-| `excludeFields` | `string[]`         | `[]`                  | Body fields to exclude when generating the request fingerprint |
-| `resilience`    | `object`           | see below             | Circuit breaker and retry configuration                        |
+| Option           | Type               | Default               | Description                                                          |
+| ---------------- | ------------------ | --------------------- | -------------------------------------------------------------------- |
+| `store`          | `IdempotencyStore` | **required**          | Storage backend for persisting idempotency records                   |
+| `required`       | `boolean`          | `true`                | Whether requests must include an `Idempotency-Key` header            |
+| `ttlMs`          | `number`           | `86400000` (24 hours) | Time-to-live in milliseconds for idempotency records                 |
+| `minKeyLength`   | `number`           | `21`                  | Minimum allowed length for idempotency keys                          |
+| `maxKeyLength`   | `number`           | `255`                 | Maximum allowed length for idempotency keys                          |
+| `excludeFields`  | `string[]`         | `[]`                  | Body fields to exclude when generating the request fingerprint       |
+| `resilience`     | `object`           | see below             | Circuit breaker and retry configuration                              |
+| `errorFormatter` | `Function`         | `undefined`           | Transform RFC 9457 problem details into a custom error response body |
 
 ### Resilience Options
 
@@ -206,6 +207,36 @@ fastify.post(
   }
 );
 ```
+
+## Custom Error Response Format
+
+By default, error responses follow [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (Problem Details for HTTP APIs). Use `errorFormatter` to make idempotency error responses match your API's existing error structure.
+
+```javascript
+idempotency({
+  store,
+  errorFormatter: (problem) => ({
+    error: problem.title,
+    message: problem.detail,
+    code: problem.status,
+    requestId: problem.instance
+  })
+});
+```
+
+The function receives the full RFC 9457 problem object with these fields:
+
+| Field             | Type      | Description                                            |
+| ----------------- | --------- | ------------------------------------------------------ |
+| `type`            | `string`  | URI identifying the error type                         |
+| `title`           | `string`  | Short, human-readable summary                          |
+| `detail`          | `string`  | Detailed explanation of what happened                  |
+| `status`          | `number`  | HTTP status code                                       |
+| `instance`        | `string`  | Unique identifier for this error occurrence            |
+| `retryable`       | `boolean` | Whether retrying the request might succeed             |
+| `idempotency_key` | `string`  | The idempotency key from the request (when applicable) |
+
+**Important:** `errorFormatter` only transforms JSON responses. When a client requests `text/markdown`, the response continues to use the raw RFC 9457 fields so the YAML frontmatter stays meaningful. When `errorFormatter` is present, JSON responses use `application/json` instead of `application/problem+json`.
 
 ## Choosing a Storage Backend
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -225,6 +225,32 @@ Error `type` URIs follow this pattern:
 
 The spec errors reference the IETF draft document. Infrastructure errors use the project's own URI space for implementation-specific issues.
 
+## Customizing Error Responses
+
+Use the `errorFormatter` configuration option to transform the default RFC 9457 response into your API's own error format:
+
+```javascript
+import { idempotency } from "@idempot/hono-middleware";
+
+app.post(
+  "/orders",
+  idempotency({
+    store,
+    errorFormatter: (problem) => ({
+      error: problem.title,
+      message: problem.detail,
+      code: problem.status,
+      requestId: problem.instance
+    })
+  }),
+  handler
+);
+```
+
+The `errorFormatter` receives the full problem object and returns the body that will be sent to the client. It only applies to JSON responses; `text/markdown` responses continue to use the raw RFC 9457 fields.
+
+When `errorFormatter` is configured, JSON responses use `application/json` as the content type instead of `application/problem+json`.
+
 ## Handling Errors
 
 ```javascript

--- a/packages/core/src/default-options.js
+++ b/packages/core/src/default-options.js
@@ -12,6 +12,7 @@
  * @property {number} [maxKeyLength] - Maximum allowed length for the Idempotency-Key header value
  * @property {number} [minKeyLength] - Minimum allowed length for the Idempotency-Key header value (default: 21)
  * @property {ResilienceOptions} [resilience] - Circuit breaker and retry configuration for store operations
+ * @property {Function} [errorFormatter] - Optional function to transform RFC 9457 problem details into a custom error response body. Receives the problem object and returns the response body. Only applied to JSON responses; markdown responses remain unchanged.
  */
 
 /** @type {Required<IdempotencyOptions>} */
@@ -36,6 +37,9 @@ const DEFAULT_OPTIONS = {
 
   /** Minimum allowed length for the Idempotency-Key header value. Default is 21 characters (nanoid default). */
   minKeyLength: 21,
+
+  /** Optional function to transform RFC 9457 problem details into a custom error response body. */
+  errorFormatter: undefined,
 
   /** Configuration for the circuit breaker and retry logic when interacting with the store. */
   resilience: {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -3,6 +3,7 @@
  * @typedef {import("./store/interface.js").IdempotencyStore} IdempotencyStore
  * @typedef {import("./resilience.js").ResilienceOptions} ResilienceOptions
  * @typedef {import("./default-options.js").IdempotencyOptions} IdempotencyOptions
+ * @typedef {import("./problem-json.js").ProblemDetails} ProblemDetails
  */
 
 export { generateFingerprint } from "./fingerprint.js";

--- a/packages/core/src/problem-json.js
+++ b/packages/core/src/problem-json.js
@@ -1,6 +1,15 @@
 /**
  * RFC 9457 Problem Details for HTTP APIs
  * @module problem-json
+ *
+ * @typedef {Object} ProblemDetails
+ * @property {string} type - URI identifying the problem type
+ * @property {string} title - Short human-readable summary
+ * @property {string} [detail] - Detailed explanation
+ * @property {number} status - HTTP status code
+ * @property {string} instance - Unique identifier for this error occurrence
+ * @property {boolean} retryable - Whether retrying might succeed
+ * @property {string} [idempotency_key] - The idempotency key from the request
  */
 
 const SPEC_URL =

--- a/packages/core/src/validation.js
+++ b/packages/core/src/validation.js
@@ -190,7 +190,8 @@ export function validateIdempotencyOptions(options = {}) {
     "store",
     "minKeyLength",
     "maxKeyLength",
-    "resilience"
+    "resilience",
+    "errorFormatter"
   ];
 
   for (const key of Object.keys(options)) {
@@ -267,6 +268,16 @@ export function validateIdempotencyOptions(options = {}) {
       );
     }
   }
+
+  // Validate errorFormatter: function or undefined
+  validateOptional(options, "errorFormatter", (v, name) => {
+    if (v === null) {
+      throw new Error(`${name} cannot be null`);
+    }
+    if (typeof v !== "function") {
+      throw new Error(`${name} must be a function`);
+    }
+  });
 
   // Validate resilience: nested object
   validateOptional(options, "resilience", (v, name) => {

--- a/packages/core/tests/framework-adapter-suite.js
+++ b/packages/core/tests/framework-adapter-suite.js
@@ -739,4 +739,97 @@ export function runAdapterTests(adapter) {
 
     await teardown();
   });
+
+  // Test: Custom errorFormatter transforms JSON error body
+  test(`${adapter.name} - custom errorFormatter transforms JSON error body`, async (t) => {
+    const store = adapter.createStore();
+    const { mount, request, teardown } = await adapter.setup();
+
+    const customFormatter = (problem) => ({
+      error: problem.title,
+      message: problem.detail,
+      code: problem.status
+    });
+
+    const middleware = adapter.createMiddleware({
+      store,
+      required: true,
+      errorFormatter: customFormatter
+    });
+
+    mount("POST", "/test", middleware, async (req, res) => {
+      return res.send({ ok: true });
+    });
+
+    const response = normalizeResponse(
+      await request({
+        method: "POST",
+        path: "/test",
+        headers: {},
+        body: { foo: "bar" }
+      })
+    );
+
+    t.equal(response.status, 400, "should return 400");
+    const contentType = response.headers["content-type"] || "";
+    t.ok(
+      contentType.includes("application/json"),
+      "should return JSON content type"
+    );
+    t.notOk(
+      contentType.includes("problem+json"),
+      "should not return problem+json"
+    );
+    t.equal(
+      response.body?.error,
+      "Idempotency-Key is missing",
+      "should have custom error field"
+    );
+    t.equal(
+      response.body?.message,
+      "This operation is idempotent and it requires correct usage of Idempotency Key.",
+      "should have custom message field"
+    );
+    t.equal(response.body?.code, 400, "should have custom code field");
+    t.notOk(response.body?.type, "should not have RFC 9457 type field");
+
+    await teardown();
+  });
+
+  // Test: Markdown format ignores errorFormatter
+  test(`${adapter.name} - markdown format ignores errorFormatter`, async (t) => {
+    const store = adapter.createStore();
+    const { mount, request, teardown } = await adapter.setup();
+
+    const customFormatter = () => ({ custom: true });
+
+    const middleware = adapter.createMiddleware({
+      store,
+      required: true,
+      errorFormatter: customFormatter
+    });
+
+    mount("POST", "/test", middleware, async (req, res) => {
+      return res.send({ ok: true });
+    });
+
+    const response = normalizeResponse(
+      await request({
+        method: "POST",
+        path: "/test",
+        headers: { accept: "text/markdown" },
+        body: { foo: "bar" }
+      })
+    );
+
+    t.equal(response.status, 400, "should return 400");
+    const body = typeof response.body === "string" ? response.body : "";
+    t.ok(body.includes("---"), "should have YAML frontmatter");
+    t.ok(
+      body.includes("Idempotency-Key is missing"),
+      "should have original title"
+    );
+
+    await teardown();
+  });
 }

--- a/packages/core/tests/problem-json.test.js
+++ b/packages/core/tests/problem-json.test.js
@@ -65,6 +65,20 @@ describe("problem-json", () => {
       assert.strictEqual(result.retryable, false);
       assert.strictEqual(result.status, 422);
     });
+
+    it("should include idempotency_key when provided", () => {
+      const result = conflictErrorResponse(
+        409,
+        "A request with this idempotency key is already being processed",
+        {
+          instance: "urn:uuid:test-concurrent",
+          idempotencyKey: "concurrent-key"
+        }
+      );
+
+      assert.strictEqual(result.idempotency_key, "concurrent-key");
+      assert.strictEqual(result.retryable, true);
+    });
   });
 
   describe("storeUnavailableResponse", () => {

--- a/packages/core/tests/validation.properties.test.js
+++ b/packages/core/tests/validation.properties.test.js
@@ -53,7 +53,8 @@ const validOptionsArbitrary = () =>
             fc.integer({ min: 1 })
           )
         })
-      )
+      ),
+      errorFormatter: fc.oneof(fc.constant(undefined), fc.func(fc.anything()))
     },
     { withDeletedKeys: true }
   );
@@ -308,7 +309,8 @@ test("validateIdempotencyOptions - unknown options throw", async (t) => {
               "store",
               "minKeyLength",
               "maxKeyLength",
-              "resilience"
+              "resilience",
+              "errorFormatter"
             ].includes(s)
         ),
       fc.anything(),

--- a/packages/core/tests/validation.test.js
+++ b/packages/core/tests/validation.test.js
@@ -140,6 +140,36 @@ test("validateIdempotencyKey - rejects keys containing commas", (t) => {
   t.end();
 });
 
+test("validateIdempotencyOptions - accepts errorFormatter as function", (t) => {
+  t.doesNotThrow(() =>
+    validateIdempotencyOptions({ errorFormatter: (problem) => problem })
+  );
+  t.end();
+});
+
+test("validateIdempotencyOptions - rejects non-function errorFormatter", (t) => {
+  t.throws(
+    () => validateIdempotencyOptions({ errorFormatter: "not a function" }),
+    {
+      message: "errorFormatter must be a function"
+    }
+  );
+  t.throws(() => validateIdempotencyOptions({ errorFormatter: 123 }), {
+    message: "errorFormatter must be a function"
+  });
+  t.throws(() => validateIdempotencyOptions({ errorFormatter: {} }), {
+    message: "errorFormatter must be a function"
+  });
+  t.end();
+});
+
+test("validateIdempotencyOptions - rejects null errorFormatter", (t) => {
+  t.throws(() => validateIdempotencyOptions({ errorFormatter: null }), {
+    message: "errorFormatter cannot be null"
+  });
+  t.end();
+});
+
 // checkLookupConflicts tests
 test("checkLookupConflicts - no conflicts when lookup is empty", (t) => {
   const lookup = { byKey: null, byFingerprint: null };

--- a/packages/frameworks/bun/index.js
+++ b/packages/frameworks/bun/index.js
@@ -37,9 +37,10 @@ const HEADER_NAME = "idempotency-key";
  * @param {string} acceptHeader - Value of the Accept request header
  * @param {number} status - HTTP status code
  * @param {Object} problem - RFC 9457 problem details
+ * @param {Function} [errorFormatter] - Optional function to transform problem details
  * @returns {Response}
  */
-const buildErrorResponse = (acceptHeader, status, problem) => {
+const buildErrorResponse = (acceptHeader, status, problem, errorFormatter) => {
   const format = selectResponseFormat(acceptHeader);
 
   if (format === "text/markdown") {
@@ -49,12 +50,14 @@ const buildErrorResponse = (acceptHeader, status, problem) => {
     });
   }
 
-  const contentType =
-    format === "application/problem+json"
+  const body = errorFormatter ? errorFormatter(problem) : problem;
+  const contentType = errorFormatter
+    ? "application/json"
+    : format === "application/problem+json"
       ? "application/problem+json"
       : "application/json";
 
-  return Response.json(problem, {
+  return Response.json(body, {
     status,
     headers: { "Content-Type": `${contentType}; charset=utf-8` }
   });
@@ -120,7 +123,12 @@ export const idempotency = (options = {}) => {
             status: 400,
             instance: instanceId
           });
-          return buildErrorResponse(acceptHeader, 400, problem);
+          return buildErrorResponse(
+            acceptHeader,
+            400,
+            problem,
+            opts.errorFormatter
+          );
         }
         return handler(req);
       }
@@ -138,7 +146,12 @@ export const idempotency = (options = {}) => {
             idempotencyKey: key
           }
         );
-        return buildErrorResponse(acceptHeader, 400, problem);
+        return buildErrorResponse(
+          acceptHeader,
+          400,
+          problem,
+          opts.errorFormatter
+        );
       }
 
       const bodyText = await req.text();
@@ -155,7 +168,12 @@ export const idempotency = (options = {}) => {
           status: 503,
           instance: instanceId
         });
-        return buildErrorResponse(acceptHeader, 503, problem);
+        return buildErrorResponse(
+          acceptHeader,
+          503,
+          problem,
+          opts.errorFormatter
+        );
       }
 
       const conflict = checkLookupConflicts(lookup, key, fingerprint);
@@ -171,7 +189,8 @@ export const idempotency = (options = {}) => {
         return buildErrorResponse(
           acceptHeader,
           /** @type {number} */ (conflict.status),
-          problem
+          problem,
+          opts.errorFormatter
         );
       }
 
@@ -192,7 +211,12 @@ export const idempotency = (options = {}) => {
             status: 503,
             instance: instanceId
           });
-          return buildErrorResponse(acceptHeader, 503, problem);
+          return buildErrorResponse(
+            acceptHeader,
+            503,
+            problem,
+            opts.errorFormatter
+          );
         }
 
         // Re-create the request so the handler can read the body again

--- a/packages/frameworks/express/index.js
+++ b/packages/frameworks/express/index.js
@@ -38,8 +38,9 @@ const HEADER_NAME = "idempotency-key";
  * @param {import("express").Response} res - Express response
  * @param {number} status - HTTP status code
  * @param {Object} problem - RFC 9457 problem details
+ * @param {Function} [errorFormatter] - Optional function to transform problem details
  */
-function sendErrorResponse(res, status, problem) {
+function sendErrorResponse(res, status, problem, errorFormatter) {
   const acceptHeader = res.req.headers["accept"] || "";
   const format = selectResponseFormat(acceptHeader);
 
@@ -49,15 +50,17 @@ function sendErrorResponse(res, status, problem) {
       .set("Content-Type", "text/markdown; charset=utf-8")
       .send(formatAsMarkdown(problem));
   } else {
-    const contentType =
-      format === "application/problem+json"
+    const body = errorFormatter ? errorFormatter(problem) : problem;
+    const contentType = errorFormatter
+      ? "application/json"
+      : format === "application/problem+json"
         ? "application/problem+json"
         : "application/json";
 
     res
       .status(status)
       .set("Content-Type", `${contentType}; charset=utf-8`)
-      .json(problem);
+      .json(body);
   }
 }
 
@@ -110,7 +113,7 @@ export function idempotency(options = {}) {
           status: 400,
           instance: instanceId
         });
-        sendErrorResponse(res, 400, problem);
+        sendErrorResponse(res, 400, problem, opts.errorFormatter);
         return;
       }
       next();
@@ -130,7 +133,7 @@ export function idempotency(options = {}) {
           idempotencyKey: key
         }
       );
-      sendErrorResponse(res, 400, problem);
+      sendErrorResponse(res, 400, problem, opts.errorFormatter);
       return;
     }
 
@@ -149,7 +152,7 @@ export function idempotency(options = {}) {
         status: 503,
         instance: instanceId
       });
-      sendErrorResponse(res, 503, problem);
+      sendErrorResponse(res, 503, problem, opts.errorFormatter);
       return;
     }
 
@@ -163,7 +166,12 @@ export function idempotency(options = {}) {
           idempotencyKey: key
         }
       );
-      sendErrorResponse(res, /** @type {number} */ (conflict.status), problem);
+      sendErrorResponse(
+        res,
+        /** @type {number} */ (conflict.status),
+        problem,
+        opts.errorFormatter
+      );
       return;
     }
 
@@ -186,7 +194,7 @@ export function idempotency(options = {}) {
           status: 503,
           instance: instanceId
         });
-        sendErrorResponse(res, 503, problem);
+        sendErrorResponse(res, 503, problem, opts.errorFormatter);
         return;
       }
 

--- a/packages/frameworks/fastify/index.js
+++ b/packages/frameworks/fastify/index.js
@@ -32,9 +32,10 @@ const HEADER_NAME = "idempotency-key";
  * @param {import("fastify").FastifyReply} reply - Fastify reply
  * @param {number} status - HTTP status code
  * @param {Object} problem - RFC 9457 problem details
+ * @param {Function} [errorFormatter] - Optional function to transform problem details
  * @returns {import("fastify").FastifyReply}
  */
-function sendErrorResponse(reply, status, problem) {
+function sendErrorResponse(reply, status, problem, errorFormatter) {
   const acceptHeader = reply.request.headers["accept"] || "";
   const format = selectResponseFormat(acceptHeader);
 
@@ -44,15 +45,17 @@ function sendErrorResponse(reply, status, problem) {
       .header("Content-Type", "text/markdown; charset=utf-8")
       .send(formatAsMarkdown(problem));
   } else {
-    const contentType =
-      format === "application/problem+json"
+    const body = errorFormatter ? errorFormatter(problem) : problem;
+    const contentType = errorFormatter
+      ? "application/json"
+      : format === "application/problem+json"
         ? "application/problem+json"
         : "application/json";
 
     return reply
       .code(status)
       .header("Content-Type", `${contentType}; charset=utf-8`)
-      .send(problem);
+      .send(body);
   }
 }
 
@@ -105,7 +108,7 @@ export function idempotency(options = {}) {
           status: 400,
           instance: instanceId
         });
-        return sendErrorResponse(reply, 400, problem);
+        return sendErrorResponse(reply, 400, problem, opts.errorFormatter);
       }
       return;
     }
@@ -123,7 +126,7 @@ export function idempotency(options = {}) {
           idempotencyKey: key
         }
       );
-      return sendErrorResponse(reply, 400, problem);
+      return sendErrorResponse(reply, 400, problem, opts.errorFormatter);
     }
 
     const bodyText = request.body
@@ -141,7 +144,7 @@ export function idempotency(options = {}) {
         status: 503,
         instance: instanceId
       });
-      return sendErrorResponse(reply, 503, problem);
+      return sendErrorResponse(reply, 503, problem, opts.errorFormatter);
     }
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
@@ -157,7 +160,8 @@ export function idempotency(options = {}) {
       return sendErrorResponse(
         reply,
         /** @type {number} */ (conflict.status),
-        problem
+        problem,
+        opts.errorFormatter
       );
     }
 
@@ -179,7 +183,7 @@ export function idempotency(options = {}) {
           status: 503,
           instance: instanceId
         });
-        return sendErrorResponse(reply, 503, problem);
+        return sendErrorResponse(reply, 503, problem, opts.errorFormatter);
       }
 
       requestMeta.set(request, { idempotencyKey: key });

--- a/packages/frameworks/hono/index.js
+++ b/packages/frameworks/hono/index.js
@@ -37,9 +37,10 @@ const HEADER_NAME = "idempotency-key";
  * @param {import("hono").Context} c - Hono context
  * @param {number} status - HTTP status code
  * @param {Object} problem - RFC 9457 problem details
+ * @param {Function} [errorFormatter] - Optional function to transform problem details
  * @returns {import("hono").Response}
  */
-function sendErrorResponse(c, status, problem) {
+function sendErrorResponse(c, status, problem, errorFormatter) {
   const acceptHeader = c.req.header("accept") || "";
   const format = selectResponseFormat(acceptHeader);
 
@@ -48,12 +49,14 @@ function sendErrorResponse(c, status, problem) {
       "Content-Type": "text/markdown; charset=utf-8"
     });
   } else {
-    const contentType =
-      format === "application/problem+json"
+    const body = errorFormatter ? errorFormatter(problem) : problem;
+    const contentType = errorFormatter
+      ? "application/json"
+      : format === "application/problem+json"
         ? "application/problem+json"
         : "application/json";
 
-    return c.json(problem, status, {
+    return c.json(body, status, {
       "Content-Type": `${contentType}; charset=utf-8`
     });
   }
@@ -108,7 +111,7 @@ export function idempotency(options = {}) {
           status: 400,
           instance: instanceId
         });
-        return sendErrorResponse(c, 400, problem);
+        return sendErrorResponse(c, 400, problem, opts.errorFormatter);
       }
       await next();
       return;
@@ -127,7 +130,7 @@ export function idempotency(options = {}) {
           idempotencyKey: key
         }
       );
-      return sendErrorResponse(c, 400, problem);
+      return sendErrorResponse(c, 400, problem, opts.errorFormatter);
     }
 
     const body = await c.req.text();
@@ -141,7 +144,7 @@ export function idempotency(options = {}) {
         status: 503,
         instance: instanceId
       });
-      return sendErrorResponse(c, 503, problem);
+      return sendErrorResponse(c, 503, problem, opts.errorFormatter);
     }
 
     const conflict = checkLookupConflicts(lookup, key, fingerprint);
@@ -157,7 +160,8 @@ export function idempotency(options = {}) {
       return sendErrorResponse(
         c,
         /** @type {number} */ (conflict.status),
-        problem
+        problem,
+        opts.errorFormatter
       );
     }
 
@@ -175,7 +179,7 @@ export function idempotency(options = {}) {
           status: 503,
           instance: instanceId
         });
-        return sendErrorResponse(c, 503, problem);
+        return sendErrorResponse(c, 503, problem, opts.errorFormatter);
       }
 
       await next();


### PR DESCRIPTION
Implements configurable error response format as requested in #126.

## What

Adds an `errorFormatter` configuration option that receives the full RFC 9457 problem-details object and returns a custom response body.

## Usage

```js
app.post(
  "/orders",
  idempotency({
    store,
    errorFormatter: (problem) => ({
      error: problem.title,
      message: problem.detail,
      code: problem.status,
      requestId: problem.instance
    })
  }),
  handler
);
```

## Behavior

- **JSON responses**: formatter output replaces the RFC 9457 body; content type becomes `application/json`
- **Markdown responses**: unchanged (raw RFC 9457 fields for meaningful YAML frontmatter)
- **Default**: no formatter → existing RFC 9457 behavior preserved (fully backward-compatible)

## Changes

- Core: `errorFormatter` added to `IdempotencyOptions`, validated in `validateIdempotencyOptions`
- All 4 framework adapters apply formatter only to JSON error responses
- Shared adapter tests verify formatter transforms JSON and ignores markdown
- Property-based tests updated to include `errorFormatter`
- Documentation updated: README, configuration guide, error reference, framework pages
- Type definitions regenerated

## Spec Compliance

RFC 9457 is the default format. Making it configurable is permitted — the IETF idempotency draft (section 2.7) shows `application/problem+json` examples but also demonstrates `Link` header alternatives, indicating the exact body structure is not mandated.

Closes #126