### PR TITLE
ci: enable Dependabot for pnpm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,18 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Configures Dependabot for npm/pnpm dependency updates with weekly schedule.