### PR TITLE
ci: enable npm provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,4 @@ jobs:
         run: NPM_CONFIG_NPMCLIENT=pnpm pnpm exec multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
 workspaces-update=false
+provenance=true


### PR DESCRIPTION
Enables npm provenance attestations via NPM_CONFIG_PROVENANCE in the release workflow.