### PR TITLE
fix(fallow): suppress oxc-minify false positive and fix duplicates override

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -23,7 +23,8 @@ entry = [
 ]
 
 # Dependencies to ignore - these are runtime-native modules (Deno/Bun)
-# that will never be in package.json
+# that will never be in package.json, or transitive dependencies required
+# by tools (e.g. VitePress/rolldown-vite) but not directly imported.
 ignoreDependencies = [
   # Deno native modules
   "@db/redis",  # Deno Redis client
@@ -31,6 +32,8 @@ ignoreDependencies = [
   "sqlite",     # Deno SQLite client
   # Bun runtime namespace
   "bun",
+  # Transitive dependency required by VitePress via rolldown-vite
+  "oxc-minify",
 ]
 
 # Patterns for files to exclude from analysis entirely
@@ -43,6 +46,5 @@ ignorePatterns = [
 
 # Override rules for specific file patterns
 # Examples and tests are expected to have duplication - ignore it
-[[overrides]]
-files = ["examples/**/*.js", "tests/**/*.js", "packages/stores/*/tests/*.js"]
-rules = { duplicates = "off" }
+[duplicates]
+ignore = ["examples/**/*.js", "tests/**/*.js", "packages/stores/*/tests/*.js"]


### PR DESCRIPTION
## Summary

Fixes two issues in `fallow.toml` that caused Fallow warnings or false positives.

## Changes

### 1. Suppress `oxc-minify` false positive

The `oxc-minify` dependency was added in `5fca2ff` as a transitive dependency required by VitePress via rolldown-vite. Fallow correctly reports it as an unused devDependency because no source file directly imports it. Add it to `ignoreDependencies` to suppress the false positive.

### 2. Fix invalid `duplicates` override

The previous `[[overrides]]` section used `rules = { duplicates = "off" }`, which Fallow warns is an unknown rule name:

```
WARN unknown rule 'duplicates' in overrides[0].rules of fallow.toml; the rule will be ignored.
```

Replace it with a proper `[duplicates]` section using the `ignore` key, which is the correct TOML config for suppressing duplication detection in specific file patterns.

## Verification

```bash
npx fallow dead-code
# ✓ No issues found (0.08s)
```

Closes #146