### PR TITLE
docs: describe response_headers as TEXT, not JSONB

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,12 +182,11 @@ All storage backends implement the `IdempotencyStore` interface. Each has differ
 **Implementation:**
 
 - Uses `pg` pool for connection management
-- JSONB column for response headers
+- TEXT column for response headers
 - Indexed queries on key and fingerprint
 
 **Similar schema to SQLite but with:**
 
-- JSONB type for headers (more efficient than TEXT)
 - Connection pooling via `pg.Pool`
 
 ### MySQL (`packages/stores/mysql/`)

--- a/docs/stores/postgres.md
+++ b/docs/stores/postgres.md
@@ -1,6 +1,6 @@
 ---
 title: PostgreSQL Store - idempot-js
-description: PostgreSQL-backed storage for idempotency middleware. Persistent storage with automatic schema creation. Uses JSONB for response headers.
+description: PostgreSQL-backed storage for idempotency middleware. Persistent storage with automatic schema creation. Uses TEXT for response headers.
 ---
 
 # PostgreSQL Store
@@ -41,7 +41,7 @@ The store creates a table named `idempotency_records` with:
 - `fingerprint` (TEXT, indexed)
 - `status` (TEXT: 'processing' or 'complete')
 - `response_status` (INTEGER)
-- `response_headers` (JSONB)
+- `response_headers` (TEXT)
 - `response_body` (TEXT)
 - `expires_at` (TIMESTAMP, indexed)
 

--- a/packages/stores/postgres/README.md
+++ b/packages/stores/postgres/README.md
@@ -38,7 +38,7 @@ The store creates a table named `idempotency_records` with:
 - `fingerprint` (TEXT, indexed)
 - `status` (TEXT: 'processing' or 'complete')
 - `response_status` (INTEGER)
-- `response_headers` (JSONB)
+- `response_headers` (TEXT)
 - `response_body` (TEXT)
 - `expires_at` (TIMESTAMP, indexed)
 


### PR DESCRIPTION
## Problem

The Postgres store schema docs claim `response_headers` is stored as `JSONB`, but the implementation has always used `TEXT` (a JSON string, parsed via `JSON.parse` in the store adapter) — see `packages/stores/postgres/index.js`.

## Why TEXT is correct

- The library never queries into the headers; the column is written once and read back whole on replay, so JSONB's indexing/querying payoff doesn't apply.
- All stores (Postgres, MySQL, SQLite) use the identical `TEXT` column + JSON-string contract, keeping the store adapters uniform.

The READMEs were aspirational; the code never followed.

## Change

- `ARCHITECTURE.md`: fix the JSONB claims (drop the now-untrue "JSONB more efficient than TEXT" bullet)
- `docs/stores/postgres.md`: fix schema description and column type
- `packages/stores/postgres/README.md`: fix column type