### PR TITLE
fix: return 409/200 on lost idempotency-key race instead of 503

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "imports": {
+    "@idempot/core": "./packages/core/src/errors.js",
     "idempot": "./src/index.js",
     "hono": "npm:hono@^4.11.5",
     "sqlite": "https://deno.land/x/sqlite/mod.ts",

--- a/packages/core/src/errors.js
+++ b/packages/core/src/errors.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when two requests race to insert the same idempotency key and
+ * the store raises a duplicate-key integrity error. The middleware treats this
+ * as a spec-compliant request conflict (409/200) rather than a store outage.
+ * @module errors
+ */
+
+/**
+ * Raised by a store when an insert races an existing idempotency key. Carries
+ * the original driver error as `cause` for diagnostics.
+ */
+export class IdempotencyKeyExistsError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "IdempotencyKeyExistsError";
+  }
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -16,6 +16,7 @@ export {
   prepareCachedResponse
 } from "./validation.js";
 export { withResilience } from "./resilience.js";
+export { IdempotencyKeyExistsError } from "./errors.js";
 export { DEFAULT_OPTIONS as defaultOptions } from "./default-options.js";
 export {
   conflictErrorResponse,

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -13,7 +13,8 @@ export {
   checkLookupConflicts,
   shouldProcessRequest,
   getCachedResponse,
-  prepareCachedResponse
+  prepareCachedResponse,
+  IDEMPOTENCY_KEY_PROCESSING_MESSAGE
 } from "./validation.js";
 export { withResilience } from "./resilience.js";
 export { IdempotencyKeyExistsError } from "./errors.js";

--- a/packages/core/src/resilience.js
+++ b/packages/core/src/resilience.js
@@ -1,4 +1,5 @@
 import CircuitBreaker from "opossum";
+import { IdempotencyKeyExistsError } from "./errors.js";
 
 /**
  * @typedef {import("./store/interface.js").IdempotencyStore} IdempotencyStore
@@ -36,7 +37,8 @@ export function withResilience(store, options = {}) {
     timeout: opts.timeoutMs,
     errorThresholdPercentage: opts.errorThresholdPercentage,
     resetTimeout: opts.resetTimeoutMs,
-    volumeThreshold: opts.volumeThreshold
+    volumeThreshold: opts.volumeThreshold,
+    errorFilter: (error) => error instanceof IdempotencyKeyExistsError
   };
 
   /**
@@ -49,6 +51,9 @@ export function withResilience(store, options = {}) {
       try {
         return await operation();
       } catch (error) {
+        if (error instanceof IdempotencyKeyExistsError) {
+          throw error;
+        }
         lastError = error;
         if (i < opts.maxRetries - 1) {
           await new Promise((r) => setTimeout(r, opts.retryDelayMs));

--- a/packages/core/src/validation.js
+++ b/packages/core/src/validation.js
@@ -1,4 +1,12 @@
 /**
+ * Message returned when an idempotency key is already being processed by a
+ * concurrent request. Exposed as a constant so the fallback path in framework
+ * middlewares can reuse the same text as `checkLookupConflicts`.
+ */
+export const IDEMPOTENCY_KEY_PROCESSING_MESSAGE =
+  "A request with this idempotency key is already being processed";
+
+/**
  * Validates that a value is a safe integer (not null, within safe range)
  * @param {*} value
  * @param {string} name
@@ -312,7 +320,7 @@ export function checkLookupConflicts(lookup, key, fingerprint) {
     return {
       conflict: true,
       status: 409,
-      error: "A request with this idempotency key is already being processed"
+      error: IDEMPOTENCY_KEY_PROCESSING_MESSAGE
     };
   }
 

--- a/packages/core/tests/errors.test.js
+++ b/packages/core/tests/errors.test.js
@@ -1,0 +1,65 @@
+// packages/core/tests/errors.test.js
+import { test } from "tap";
+import { IdempotencyKeyExistsError } from "@idempot/core";
+import { IdempotencyKeyExistsError as DirectImport } from "../src/errors.js";
+
+test("IdempotencyKeyExistsError - is an Error subtype with its own name", (t) => {
+  const err = new IdempotencyKeyExistsError();
+  t.ok(err instanceof Error, "instanceof Error");
+  t.equal(err.name, "IdempotencyKeyExistsError", "carries its own name");
+  t.end();
+});
+
+test("IdempotencyKeyExistsError - retains the message when provided", (t) => {
+  const withMessage = new IdempotencyKeyExistsError(
+    "duplicate key in idempotency store"
+  );
+  t.equal(withMessage.message, "duplicate key in idempotency store");
+  t.ok(withMessage instanceof Error);
+  t.end();
+});
+
+test("IdempotencyKeyExistsError - empty message when constructed without one", (t) => {
+  const noMessage = new IdempotencyKeyExistsError();
+  t.equal(noMessage.message, "", "defaults to empty message");
+  t.end();
+});
+
+test("IdempotencyKeyExistsError - preserves the original error as cause", (t) => {
+  const cause = new Error(
+    "23505: duplicate key value violates unique constraint"
+  );
+  const err = new IdempotencyKeyExistsError("idempotency key exists", {
+    cause
+  });
+  t.equal(err.cause, cause, "exposes the original driver error");
+  t.end();
+});
+
+test("IdempotencyKeyExistsError - single shared class identity across imports", (t) => {
+  t.equal(
+    IdempotencyKeyExistsError,
+    DirectImport,
+    "package export and engine module export are the same class"
+  );
+
+  const viaPackage = new IdempotencyKeyExistsError();
+  const viaModule = new DirectImport();
+  t.ok(
+    viaPackage instanceof IdempotencyKeyExistsError,
+    "package instance is instanceof the package import"
+  );
+  t.ok(
+    viaModule instanceof IdempotencyKeyExistsError,
+    "module instance is instanceof the package import"
+  );
+  t.ok(
+    viaPackage instanceof DirectImport,
+    "package instance is instanceof the module import"
+  );
+  t.ok(
+    viaModule instanceof DirectImport,
+    "module instance is instanceof the module import"
+  );
+  t.end();
+});

--- a/packages/core/tests/race-store-helper.js
+++ b/packages/core/tests/race-store-helper.js
@@ -1,0 +1,51 @@
+import { IdempotencyKeyExistsError } from "@idempot/core";
+
+/**
+ * Shared key used by framework middleware race tests.
+ */
+export const RACE_KEY = "race-test-key-1234567890-abcdef";
+
+/**
+ * Creates a stub idempotency store that deterministically exercises the
+ * middleware's catch-and-reroute path. The first `lookup()` always misses so
+ * the request reaches `startProcessing`; subsequent lookups simulate the
+ * re-check after a duplicate-key error.
+ *
+ * @param {Object} opts
+ * @param {{status: string, fingerprint?: string, response?: any} | null} opts.secondLookup - record returned by the re-lookup (null = no record)
+ * @param {Error | null} [opts.relookupError] - error thrown by the re-lookup
+ * @param {Error | null} [opts.startError] - error thrown by startProcessing
+ * @returns {import("@idempot/core").IdempotencyStore}
+ */
+export function createRaceStubStore(opts) {
+  let fingerprintSeen = null;
+  let lookupCount = 0;
+  return {
+    async lookup(key, fingerprint) {
+      lookupCount++;
+      if (lookupCount === 1) {
+        fingerprintSeen = fingerprint;
+        return { byKey: null, byFingerprint: null };
+      }
+      if (opts.relookupError) {
+        throw opts.relookupError;
+      }
+      if (!opts.secondLookup) {
+        return { byKey: null, byFingerprint: null };
+      }
+      const record = { key, fingerprint: fingerprintSeen };
+      if (opts.secondLookup.status === "complete") {
+        record.status = "complete";
+        record.response = opts.secondLookup.response;
+      } else {
+        record.status = "processing";
+      }
+      return { byKey: record, byFingerprint: null };
+    },
+    async startProcessing() {
+      throw opts.startError ?? new IdempotencyKeyExistsError("duplicate key");
+    },
+    async complete() {},
+    async close() {}
+  };
+}

--- a/packages/core/tests/resilience.test.js
+++ b/packages/core/tests/resilience.test.js
@@ -1,5 +1,5 @@
 import { test } from "tap";
-import { withResilience } from "@idempot/core";
+import { withResilience, IdempotencyKeyExistsError } from "@idempot/core";
 
 test("withResilience - wraps store operations", async (t) => {
   let lookupCalled = false;
@@ -70,6 +70,65 @@ test("withResilience - throws after max retries", async (t) => {
   }
 });
 
+test("withResilience - key-exists error is invoked once and not retried", async (t) => {
+  let attempts = 0;
+  const duplicateStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      attempts++;
+      throw new IdempotencyKeyExistsError("duplicate key");
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(duplicateStore, { maxRetries: 3 });
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    IdempotencyKeyExistsError,
+    "key-exists error should propagate to caller"
+  );
+  t.equal(attempts, 1, "key-exists error should not be retried");
+});
+
+test("withResilience - key-exists error keeps the circuit closed", async (t) => {
+  let attempts = 0;
+  const duplicateThenSuccessStore = {
+    lookup: async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new IdempotencyKeyExistsError("duplicate key");
+      }
+      return { byKey: null, byFingerprint: null };
+    },
+    startProcessing: async () => {},
+    complete: async () => {}
+  };
+
+  const { store, circuit } = withResilience(duplicateThenSuccessStore, {
+    maxRetries: 1,
+    errorThresholdPercentage: 1,
+    volumeThreshold: 1
+  });
+
+  await t.rejects(
+    store.lookup("key", "fp"),
+    IdempotencyKeyExistsError,
+    "first lookups throws key-exists error"
+  );
+
+  const result = await store.lookup("key", "fp");
+  t.same(
+    result,
+    { byKey: null, byFingerprint: null },
+    "subsequent call succeeds"
+  );
+  t.notOk(
+    circuit.opened,
+    "circuit should remain closed after key-exists error"
+  );
+});
+
 test("withResilience - respects timeout", async (t) => {
   const slowStore = {
     lookup: async () => {
@@ -80,7 +139,7 @@ test("withResilience - respects timeout", async (t) => {
     complete: async () => {}
   };
 
-  const { store, circuit } = withResilience(slowStore, { timeoutMs: 100 });
+  const { store } = withResilience(slowStore, { timeoutMs: 100 });
 
   try {
     await store.lookup("key", "fp");
@@ -91,10 +150,10 @@ test("withResilience - respects timeout", async (t) => {
 });
 
 test("withResilience - circuit breaker opens after failures", async (t) => {
-  let attempts = 0;
+  let _attempts = 0;
   const failingStore = {
     lookup: async () => {
-      attempts++;
+      _attempts++;
       throw new Error("Failure");
     },
     startProcessing: async () => {},
@@ -110,7 +169,7 @@ test("withResilience - circuit breaker opens after failures", async (t) => {
   // First call should fail
   try {
     await store.lookup("key", "fp");
-  } catch (e) {
+  } catch {
     // Expected
   }
 

--- a/packages/frameworks/bun/bun-handler.test.js
+++ b/packages/frameworks/bun/bun-handler.test.js
@@ -2,6 +2,10 @@ import { test } from "tap";
 import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+import {
+  createRaceStubStore,
+  RACE_KEY
+} from "../../core/tests/race-store-helper.js";
 
 test("bun - returns markdown format when Accept: text/markdown", async (t) => {
   const store = new SqliteIdempotencyStore({ path: ":memory:" });
@@ -61,6 +65,78 @@ test("bun - returns JSON format when Accept: application/json", async (t) => {
   t.ok(body.type, "should have type field in JSON body");
 
   await store.close();
+});
+
+// --- Lost-race reroute: startProcessing throws IdempotencyKeyExistsError ---
+
+async function raceRequest(store) {
+  const wrap = idempotency({ store, required: true });
+  const handler = wrap(async () => Response.json({ ok: true }));
+  return handler(
+    new Request("http://localhost/test", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": RACE_KEY
+      },
+      body: JSON.stringify({})
+    })
+  );
+}
+
+test("bun - lost race with winner still processing returns 409", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: { status: "processing" }
+  });
+  const res = await raceRequest(store);
+
+  t.equal(res.status, 409, "loser should get 409 conflict");
+  const body = await res.json();
+  t.match(body.type, /#section-2\.6$/, "conflict references spec section 2.6");
+});
+
+test("bun - lost race with winner complete replays cached response 200", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: {
+      status: "complete",
+      response: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"winner":true}'
+      }
+    }
+  });
+  const res = await raceRequest(store);
+
+  t.equal(res.status, 200, "loser should get 200 replay");
+  t.equal(await res.text(), '{"winner":true}', "replays winner body");
+});
+
+test("bun - lost race re-lookup finds no record returns 409", async (t) => {
+  const store = createRaceStubStore({ secondLookup: null });
+  const res = await raceRequest(store);
+
+  t.equal(res.status, 409, "no-record re-lookup returns 409 per KTD2");
+});
+
+test("bun - lost race re-lookup throws returns 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    relookupError: new Error("connection refused")
+  });
+  const res = await raceRequest(store);
+
+  t.equal(res.status, 503, "re-lookup failure stays a 503");
+});
+
+test("bun - non-key-exists error from startProcessing stays 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    startError: new Error("connection refused")
+  });
+  const res = await raceRequest(store);
+
+  t.equal(res.status, 503, "unrelated store error stays a 503");
 });
 
 runAdapterTests({

--- a/packages/frameworks/bun/index.js
+++ b/packages/frameworks/bun/index.js
@@ -21,7 +21,9 @@ import {
   missingKeyResponse,
   storeUnavailableResponse,
   selectResponseFormat,
-  formatAsMarkdown
+  formatAsMarkdown,
+  IdempotencyKeyExistsError,
+  IDEMPOTENCY_KEY_PROCESSING_MESSAGE
 } from "@idempot/core";
 
 /**
@@ -187,7 +189,62 @@ export const idempotency = (options = {}) => {
       if (!lookup.byKey && !lookup.byFingerprint) {
         try {
           await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
-        } catch {
+        } catch (error) {
+          if (error instanceof IdempotencyKeyExistsError) {
+            let recheck;
+            try {
+              recheck = await resilientStore.lookup(key, fingerprint);
+            } catch {
+              const problem = storeUnavailableResponse({
+                status: 503,
+                instance: instanceId
+              });
+              return buildErrorResponse(acceptHeader, 503, problem);
+            }
+
+            const recheckConflict = checkLookupConflicts(
+              recheck,
+              key,
+              fingerprint
+            );
+            if (recheckConflict.conflict) {
+              const problem = conflictErrorResponse(
+                /** @type {number} */ (recheckConflict.status),
+                /** @type {string} */ (recheckConflict.error),
+                {
+                  instance: instanceId,
+                  idempotencyKey: key
+                }
+              );
+              return buildErrorResponse(
+                acceptHeader,
+                /** @type {number} */ (recheckConflict.status),
+                problem
+              );
+            }
+
+            const cached = getCachedResponse(recheck);
+            if (cached) {
+              const response = prepareCachedResponse(cached);
+              return new Response(response.body, {
+                status: response.status,
+                headers: response.headers
+              });
+            }
+
+            // No record found (winner's record may have expired): per KTD2 the
+            // loser still gets a 409 conflict and the client retries fresh.
+            const problem = conflictErrorResponse(
+              409,
+              IDEMPOTENCY_KEY_PROCESSING_MESSAGE,
+              {
+                instance: instanceId,
+                idempotencyKey: key
+              }
+            );
+            return buildErrorResponse(acceptHeader, 409, problem);
+          }
+
           const problem = storeUnavailableResponse({
             status: 503,
             instance: instanceId

--- a/packages/frameworks/express/express-middleware.test.js
+++ b/packages/frameworks/express/express-middleware.test.js
@@ -4,6 +4,10 @@ import http from "http";
 import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+import {
+  createRaceStubStore,
+  RACE_KEY
+} from "../../core/tests/race-store-helper.js";
 
 // Content negotiation tests
 test("express - returns markdown format when Accept: text/markdown", async (t) => {
@@ -112,6 +116,110 @@ test("express - returns JSON format when Accept: application/json", async (t) =>
 
   server.close();
   await store.close();
+});
+
+// --- Lost-race reroute: startProcessing throws IdempotencyKeyExistsError ---
+
+async function raceRequest(store) {
+  const app = express();
+  app.use(express.json());
+  app.post("/test", idempotency({ store, required: true }), (req, res) =>
+    res.json({ ok: true })
+  );
+
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const response = await new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "localhost",
+        port,
+        path: "/test",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": RACE_KEY
+        }
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: data
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(JSON.stringify({}));
+    req.end();
+  });
+
+  server.close();
+  return response;
+}
+
+test("express - lost race with winner still processing returns 409", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: { status: "processing" }
+  });
+  const response = await raceRequest(store);
+
+  t.equal(response.status, 409, "loser should get 409 conflict");
+  t.match(
+    JSON.parse(response.body).type,
+    /#section-2\.6$/,
+    "conflict references spec section 2.6"
+  );
+});
+
+test("express - lost race with winner complete replays cached response 200", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: {
+      status: "complete",
+      response: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"winner":true}'
+      }
+    }
+  });
+  const response = await raceRequest(store);
+
+  t.equal(response.status, 200, "loser should get 200 replay");
+  t.equal(response.body, '{"winner":true}', "replays winner body");
+});
+
+test("express - lost race re-lookup finds no record returns 409", async (t) => {
+  const store = createRaceStubStore({ secondLookup: null });
+  const response = await raceRequest(store);
+
+  t.equal(response.status, 409, "no-record re-lookup returns 409 per KTD2");
+});
+
+test("express - lost race re-lookup throws returns 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    relookupError: new Error("connection refused")
+  });
+  const response = await raceRequest(store);
+
+  t.equal(response.status, 503, "re-lookup failure stays a 503");
+});
+
+test("express - non-key-exists error from startProcessing stays 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    startError: new Error("connection refused")
+  });
+  const response = await raceRequest(store);
+
+  t.equal(response.status, 503, "unrelated store error stays a 503");
 });
 
 // Run shared adapter test suite

--- a/packages/frameworks/express/index.js
+++ b/packages/frameworks/express/index.js
@@ -22,7 +22,9 @@ import {
   missingKeyResponse,
   storeUnavailableResponse,
   selectResponseFormat,
-  formatAsMarkdown
+  formatAsMarkdown,
+  IdempotencyKeyExistsError,
+  IDEMPOTENCY_KEY_PROCESSING_MESSAGE
 } from "@idempot/core";
 
 /**
@@ -181,7 +183,67 @@ export function idempotency(options = {}) {
     if (!lookup.byKey && !lookup.byFingerprint) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
-      } catch {
+      } catch (error) {
+        if (error instanceof IdempotencyKeyExistsError) {
+          let recheck;
+          try {
+            recheck = await resilientStore.lookup(key, fingerprint);
+          } catch {
+            const problem = storeUnavailableResponse({
+              status: 503,
+              instance: instanceId
+            });
+            sendErrorResponse(res, 503, problem);
+            return;
+          }
+
+          const recheckConflict = checkLookupConflicts(
+            recheck,
+            key,
+            fingerprint
+          );
+          if (recheckConflict.conflict) {
+            const problem = conflictErrorResponse(
+              /** @type {number} */ (recheckConflict.status),
+              /** @type {string} */ (recheckConflict.error),
+              {
+                instance: instanceId,
+                idempotencyKey: key
+              }
+            );
+            sendErrorResponse(
+              res,
+              /** @type {number} */ (recheckConflict.status),
+              problem
+            );
+            return;
+          }
+
+          const cached = getCachedResponse(recheck);
+          if (cached) {
+            const response = prepareCachedResponse(cached);
+            res.status(response.status);
+            for (const [headerKey, value] of Object.entries(response.headers)) {
+              res.set(headerKey, value);
+            }
+            res.send(response.body);
+            return;
+          }
+
+          // No record found (winner's record may have expired): per KTD2 the
+          // loser still gets a 409 conflict and the client retries fresh.
+          const problem = conflictErrorResponse(
+            409,
+            IDEMPOTENCY_KEY_PROCESSING_MESSAGE,
+            {
+              instance: instanceId,
+              idempotencyKey: key
+            }
+          );
+          sendErrorResponse(res, 409, problem);
+          return;
+        }
+
         const problem = storeUnavailableResponse({
           status: 503,
           instance: instanceId

--- a/packages/frameworks/fastify/fastify-middleware.test.js
+++ b/packages/frameworks/fastify/fastify-middleware.test.js
@@ -3,6 +3,10 @@ import Fastify from "fastify";
 import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+import {
+  createRaceStubStore,
+  RACE_KEY
+} from "../../core/tests/race-store-helper.js";
 
 // Run shared adapter test suite
 runAdapterTests({
@@ -52,7 +56,7 @@ test("fastify - returns markdown format when Accept: text/markdown", async (t) =
   app.post(
     "/test",
     { preHandler: idempotency({ store, required: true }) },
-    async (request, reply) => {
+    async (_request, _reply) => {
       return { ok: true };
     }
   );
@@ -84,7 +88,7 @@ test("fastify - returns JSON format when Accept: application/json", async (t) =>
   app.post(
     "/test",
     { preHandler: idempotency({ store, required: true }) },
-    async (request, reply) => {
+    async (_request, _reply) => {
       return { ok: true };
     }
   );
@@ -131,7 +135,7 @@ test("fastify - handles handler that returns value without calling send", async 
   app.post(
     "/test",
     { preHandler: idempotency({ store }) },
-    async (request, reply) => {
+    async (_request, _reply) => {
       return { direct: "return" };
     }
   );
@@ -160,7 +164,7 @@ test("fastify - handles handler that sends undefined", async (t) => {
   app.post(
     "/test",
     { preHandler: idempotency({ store }) },
-    async (request, reply) => {
+    async (_request, reply) => {
       return reply.send(undefined);
     }
   );
@@ -173,4 +177,154 @@ test("fastify - handles handler that sends undefined", async (t) => {
   });
 
   t.equal(response.statusCode, 200);
+});
+
+// --- Lost-race reroute: startProcessing throws IdempotencyKeyExistsError ---
+
+test("fastify - lost race with winner still processing returns 409", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: { status: "processing" }
+  });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async () => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      "idempotency-key": RACE_KEY
+    }
+  });
+
+  t.equal(response.statusCode, 409, "loser should get 409 conflict");
+  t.match(
+    response.json().type,
+    /#section-2\.6$/,
+    "conflict references spec section 2.6"
+  );
+});
+
+test("fastify - lost race with winner complete replays cached response 200", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: {
+      status: "complete",
+      response: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"winner":true}'
+      }
+    }
+  });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async () => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      "idempotency-key": RACE_KEY
+    }
+  });
+
+  t.equal(response.statusCode, 200, "loser should get 200 replay");
+  t.equal(response.body, '{"winner":true}', "replays winner body");
+});
+
+test("fastify - lost race re-lookup finds no record returns 409", async (t) => {
+  const store = createRaceStubStore({ secondLookup: null });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async () => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      "idempotency-key": RACE_KEY
+    }
+  });
+
+  t.equal(response.statusCode, 409, "no-record re-lookup returns 409 per KTD2");
+});
+
+test("fastify - lost race re-lookup throws returns 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    relookupError: new Error("connection refused")
+  });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async () => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      "idempotency-key": RACE_KEY
+    }
+  });
+
+  t.equal(response.statusCode, 503, "re-lookup failure stays a 503");
+});
+
+test("fastify - non-key-exists error from startProcessing stays 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    startError: new Error("connection refused")
+  });
+  const app = Fastify();
+
+  app.post(
+    "/test",
+    { preHandler: idempotency({ store, required: true }) },
+    async () => {
+      return { ok: true };
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/test",
+    payload: {},
+    headers: {
+      "Content-Type": "application/json",
+      "idempotency-key": RACE_KEY
+    }
+  });
+
+  t.equal(response.statusCode, 503, "unrelated store error stays a 503");
 });

--- a/packages/frameworks/fastify/index.js
+++ b/packages/frameworks/fastify/index.js
@@ -22,7 +22,9 @@ import {
   missingKeyResponse,
   storeUnavailableResponse,
   selectResponseFormat,
-  formatAsMarkdown
+  formatAsMarkdown,
+  IdempotencyKeyExistsError,
+  IDEMPOTENCY_KEY_PROCESSING_MESSAGE
 } from "@idempot/core";
 
 const HEADER_NAME = "idempotency-key";
@@ -174,7 +176,63 @@ export function idempotency(options = {}) {
     if (!lookup.byKey && !lookup.byFingerprint) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
-      } catch {
+      } catch (error) {
+        if (error instanceof IdempotencyKeyExistsError) {
+          let recheck;
+          try {
+            recheck = await resilientStore.lookup(key, fingerprint);
+          } catch {
+            const problem = storeUnavailableResponse({
+              status: 503,
+              instance: instanceId
+            });
+            return sendErrorResponse(reply, 503, problem);
+          }
+
+          const recheckConflict = checkLookupConflicts(
+            recheck,
+            key,
+            fingerprint
+          );
+          if (recheckConflict.conflict) {
+            const problem = conflictErrorResponse(
+              /** @type {number} */ (recheckConflict.status),
+              /** @type {string} */ (recheckConflict.error),
+              {
+                instance: instanceId,
+                idempotencyKey: key
+              }
+            );
+            return sendErrorResponse(
+              reply,
+              /** @type {number} */ (recheckConflict.status),
+              problem
+            );
+          }
+
+          const cached = getCachedResponse(recheck);
+          if (cached) {
+            const response = prepareCachedResponse(cached);
+            reply.code(response.status);
+            for (const [headerKey, value] of Object.entries(response.headers)) {
+              reply.header(headerKey, /** @type {string} */ (value));
+            }
+            return reply.send(response.body);
+          }
+
+          // No record found (winner's record may have expired): per KTD2 the
+          // loser still gets a 409 conflict and the client retries fresh.
+          const problem = conflictErrorResponse(
+            409,
+            IDEMPOTENCY_KEY_PROCESSING_MESSAGE,
+            {
+              instance: instanceId,
+              idempotencyKey: key
+            }
+          );
+          return sendErrorResponse(reply, 409, problem);
+        }
+
         const problem = storeUnavailableResponse({
           status: 503,
           instance: instanceId

--- a/packages/frameworks/hono/hono-middleware.test.js
+++ b/packages/frameworks/hono/hono-middleware.test.js
@@ -3,6 +3,10 @@ import { test } from "tap";
 import { runAdapterTests } from "../../core/tests/framework-adapter-suite.js";
 import { idempotency } from "./index.js";
 import { SqliteIdempotencyStore } from "@idempot/sqlite-store";
+import {
+  createRaceStubStore,
+  RACE_KEY
+} from "../../core/tests/race-store-helper.js";
 
 // Content negotiation tests
 test("hono - returns markdown format when Accept: text/markdown", async (t) => {
@@ -61,6 +65,119 @@ test("hono - returns JSON format when Accept: application/json", async (t) => {
   t.ok(body.type, "should have type field in JSON body");
 
   await store.close();
+});
+
+// --- Lost-race reroute: startProcessing throws IdempotencyKeyExistsError ---
+
+test("hono - lost race with winner still processing returns 409", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: { status: "processing" }
+  });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": RACE_KEY
+    },
+    body: JSON.stringify({})
+  });
+
+  t.equal(res.status, 409, "loser should get 409 conflict");
+  const body = await res.json();
+  t.match(body.type, /#section-2\.6$/, "conflict references spec section 2.6");
+  t.equal(body.retryable, true, "concurrent conflict is retryable");
+});
+
+test("hono - lost race with winner complete replays cached response 200", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: {
+      status: "complete",
+      response: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"winner":true}'
+      }
+    }
+  });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": RACE_KEY
+    },
+    body: JSON.stringify({})
+  });
+
+  t.equal(res.status, 200, "loser should get 200 replay");
+  t.equal(await res.text(), '{"winner":true}', "replays winner body");
+});
+
+test("hono - lost race re-lookup finds no record returns 409", async (t) => {
+  const store = createRaceStubStore({ secondLookup: null });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": RACE_KEY
+    },
+    body: JSON.stringify({})
+  });
+
+  t.equal(res.status, 409, "no-record re-lookup returns 409 per KTD2");
+});
+
+test("hono - lost race re-lookup throws returns 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    relookupError: new Error("connection refused")
+  });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": RACE_KEY
+    },
+    body: JSON.stringify({})
+  });
+
+  t.equal(res.status, 503, "re-lookup failure stays a 503");
+});
+
+test("hono - non-key-exists error from startProcessing stays 503", async (t) => {
+  const store = createRaceStubStore({
+    secondLookup: null,
+    startError: new Error("connection refused")
+  });
+  const app = new Hono();
+  const middleware = idempotency({ store, required: true });
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+
+  const res = await app.request("http://localhost/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": RACE_KEY
+    },
+    body: JSON.stringify({})
+  });
+
+  t.equal(res.status, 503, "unrelated store error stays a 503");
 });
 
 // Run shared adapter test suite

--- a/packages/frameworks/hono/index.js
+++ b/packages/frameworks/hono/index.js
@@ -21,7 +21,9 @@ import {
   missingKeyResponse,
   storeUnavailableResponse,
   selectResponseFormat,
-  formatAsMarkdown
+  formatAsMarkdown,
+  IdempotencyKeyExistsError,
+  IDEMPOTENCY_KEY_PROCESSING_MESSAGE
 } from "@idempot/core";
 
 /**
@@ -170,7 +172,59 @@ export function idempotency(options = {}) {
     if (!lookup.byKey && !lookup.byFingerprint) {
       try {
         await resilientStore.startProcessing(key, fingerprint, opts.ttlMs);
-      } catch {
+      } catch (error) {
+        if (error instanceof IdempotencyKeyExistsError) {
+          let recheck;
+          try {
+            recheck = await resilientStore.lookup(key, fingerprint);
+          } catch {
+            const problem = storeUnavailableResponse({
+              status: 503,
+              instance: instanceId
+            });
+            return sendErrorResponse(c, 503, problem);
+          }
+
+          const recheckConflict = checkLookupConflicts(
+            recheck,
+            key,
+            fingerprint
+          );
+          if (recheckConflict.conflict) {
+            const problem = conflictErrorResponse(
+              /** @type {number} */ (recheckConflict.status),
+              /** @type {string} */ (recheckConflict.error),
+              {
+                instance: instanceId,
+                idempotencyKey: key
+              }
+            );
+            return sendErrorResponse(
+              c,
+              /** @type {number} */ (recheckConflict.status),
+              problem
+            );
+          }
+
+          const cached = getCachedResponse(recheck);
+          if (cached) {
+            const response = prepareCachedResponse(cached);
+            return c.body(response.body, response.status, response.headers);
+          }
+
+          // No record found (winner's record may have expired): per KTD2 the
+          // loser still gets a 409 conflict and the client retries fresh.
+          const problem = conflictErrorResponse(
+            409,
+            IDEMPOTENCY_KEY_PROCESSING_MESSAGE,
+            {
+              instance: instanceId,
+              idempotencyKey: key
+            }
+          );
+          return sendErrorResponse(c, 409, problem);
+        }
+
         const problem = storeUnavailableResponse({
           status: 503,
           instance: instanceId

--- a/packages/stores/bun-sql/index.js
+++ b/packages/stores/bun-sql/index.js
@@ -5,6 +5,7 @@
 
 // @ts-nocheck - bun:sqlite and bun:sql are only available in Bun runtime
 import { Database } from "bun:sqlite";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 /**
  * @typedef {Object} BunSqlIdempotencyStoreOptions
@@ -314,30 +315,49 @@ export class BunSqlIdempotencyStore {
   async startProcessing(key, fingerprint, ttlMs) {
     await this.ensureSchema();
 
-    if (this.isSqlite) {
-      this.db
-        .prepare(
-          `
+    try {
+      if (this.isSqlite) {
+        this.db
+          .prepare(
+            `
         INSERT INTO idempotency_records
         (key, fingerprint, status, expires_at)
         VALUES (?, ?, 'processing', ?)
       `
-        )
-        .run(key, fingerprint, Date.now() + ttlMs);
-    } else {
-      const keyColumn = this.isMySQL ? "`key`" : '"key"';
-
-      if (this.isMySQL) {
-        await this.db.unsafe(
-          `INSERT INTO idempotency_records (${keyColumn}, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
-          [key, fingerprint, Date.now() + ttlMs]
-        );
+          )
+          .run(key, fingerprint, Date.now() + ttlMs);
       } else {
-        await this.db.unsafe(
-          `INSERT INTO idempotency_records (${keyColumn}, fingerprint, status, expires_at) VALUES ($1, $2, 'processing', $3)`,
-          [key, fingerprint, Date.now() + ttlMs]
+        const keyColumn = this.isMySQL ? "`key`" : '"key"';
+
+        if (this.isMySQL) {
+          await this.db.unsafe(
+            `INSERT INTO idempotency_records (${keyColumn}, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
+            [key, fingerprint, Date.now() + ttlMs]
+          );
+        } else {
+          await this.db.unsafe(
+            `INSERT INTO idempotency_records (${keyColumn}, fingerprint, status, expires_at) VALUES ($1, $2, 'processing', $3)`,
+            [key, fingerprint, Date.now() + ttlMs]
+          );
+        }
+      }
+    } catch (error) {
+      const isDuplicateKey =
+        error?.code === "SQLITE_CONSTRAINT_PRIMARYKEY" ||
+        error?.code === "23505" ||
+        error?.errno === "23505" ||
+        error?.errno === 1062 ||
+        (typeof error?.message === "string" &&
+          (error.message.includes("UNIQUE constraint failed") ||
+            error.message.includes("Duplicate entry") ||
+            error.message.includes("duplicate key value violates")));
+      if (isDuplicateKey) {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
         );
       }
+      throw error;
     }
   }
 

--- a/packages/stores/mysql/deno-mysql.js
+++ b/packages/stores/mysql/deno-mysql.js
@@ -17,6 +17,7 @@
 
 // @ts-nocheck - Deno runtime only
 import { Client } from "mysql";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 /**
  * @typedef {Object} MysqlIdempotencyStoreOptions
@@ -153,10 +154,24 @@ export class MysqlIdempotencyStore {
    * @returns {Promise<void>}
    */
   async startProcessing(key, fingerprint, ttlMs) {
-    await this.client.execute(
-      "INSERT INTO idempotency_records (`key`, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)",
-      [key, fingerprint, Date.now() + ttlMs]
-    );
+    try {
+      await this.client.execute(
+        "INSERT INTO idempotency_records (`key`, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)",
+        [key, fingerprint, Date.now() + ttlMs]
+      );
+    } catch (error) {
+      const isDuplicateKey =
+        error?.code === "ER_DUP_ENTRY" ||
+        (typeof error?.message === "string" &&
+          error.message.includes("Duplicate entry"));
+      if (isDuplicateKey) {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/stores/mysql/mysql.test.js
+++ b/packages/stores/mysql/mysql.test.js
@@ -50,3 +50,55 @@ test("MysqlIdempotencyStore - close calls pool.end", async (t) => {
   t.equal(pool.end.calledOnce, true, "pool.end should be called once");
   t.end();
 });
+
+test("MysqlIdempotencyStore - startProcessing on existing key throws IdempotencyKeyExistsError", async (t) => {
+  const { IdempotencyKeyExistsError } = await import("@idempot/core");
+  const pool = createFakeMysqlPool();
+  const store = new MysqlIdempotencyStore({ pool });
+
+  await store.startProcessing("dup-key", "fp-1", 60000);
+
+  await t.rejects(
+    store.startProcessing("dup-key", "fp-2", 60000),
+    IdempotencyKeyExistsError,
+    "duplicate insert should throw IdempotencyKeyExistsError"
+  );
+
+  await store.close();
+  t.end();
+});
+
+test("MysqlIdempotencyStore - startProcessing propagates non-constraint driver errors", async (t) => {
+  const pool = createFakeMysqlPool();
+  const store = new MysqlIdempotencyStore({ pool });
+
+  pool.__insertError = new Error("connection refused");
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    /connection refused/,
+    "transient driver error should propagate unchanged"
+  );
+
+  await store.close();
+  t.end();
+});
+
+test("MysqlIdempotencyStore - startProcessing translates message-only duplicate errors", async (t) => {
+  const { IdempotencyKeyExistsError } = await import("@idempot/core");
+  const pool = createFakeMysqlPool();
+  const store = new MysqlIdempotencyStore({ pool });
+
+  // Some mysql drivers omit the code and expose only the message.
+  const messageOnly = new Error("Duplicate entry 'key' for key 'PRIMARY'");
+  pool.__insertError = messageOnly;
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    IdempotencyKeyExistsError,
+    "message-only duplicate errors should be translated"
+  );
+
+  await store.close();
+  t.end();
+});

--- a/packages/stores/mysql/node-mysql.js
+++ b/packages/stores/mysql/node-mysql.js
@@ -4,6 +4,7 @@
  */
 
 import { createRequire } from "module";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 const require = createRequire(import.meta.url);
 
@@ -118,10 +119,24 @@ export class MysqlIdempotencyStore {
    * @returns {Promise<void>}
    */
   async startProcessing(key, fingerprint, ttlMs) {
-    await this.pool.query(
-      `INSERT INTO \`${this.tableName}\` (\`key\`, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
-      [key, fingerprint, Date.now() + ttlMs]
-    );
+    try {
+      await this.pool.query(
+        `INSERT INTO \`${this.tableName}\` (\`key\`, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
+        [key, fingerprint, Date.now() + ttlMs]
+      );
+    } catch (error) {
+      const isDuplicate =
+        error?.code === "ER_DUP_ENTRY" ||
+        (typeof error?.message === "string" &&
+          error.message.includes("Duplicate entry"));
+      if (isDuplicate) {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/stores/mysql/tests/mysql-test-helpers.js
+++ b/packages/stores/mysql/tests/mysql-test-helpers.js
@@ -41,6 +41,11 @@ export function createFakeMysqlPool() {
 
   const pool = {
     __store: store,
+    /**
+     * Optional injected error thrown by INSERT operations.
+     * @type {Error | null}
+     */
+    __insertError: null,
 
     query: sinon.fake(async (sql, params = []) => {
       const parsed = parseSql(sql);
@@ -62,7 +67,17 @@ export function createFakeMysqlPool() {
       }
 
       if (parsed.operation === "INSERT") {
+        if (pool.__insertError) {
+          const injected = pool.__insertError;
+          pool.__insertError = null;
+          throw injected;
+        }
         const [key, fingerprint, expiresAt] = params;
+        if (store.has(key)) {
+          const error = new Error(`Duplicate entry '${key}' for key 'PRIMARY'`);
+          error.code = "ER_DUP_ENTRY";
+          throw error;
+        }
         store.set(key, {
           key,
           fingerprint,

--- a/packages/stores/postgres/index.js
+++ b/packages/stores/postgres/index.js
@@ -4,6 +4,7 @@
  */
 
 import { createRequire } from "module";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 const require = createRequire(import.meta.url);
 
@@ -144,11 +145,21 @@ export class PostgresIdempotencyStore {
    * @returns {Promise<void>}
    */
   async startProcessing(key, fingerprint, ttlMs) {
-    await this.pool.query(
-      `INSERT INTO ${this.quotedSchemaIdentifier}.idempotency_records (key, fingerprint, status, expires_at)
+    try {
+      await this.pool.query(
+        `INSERT INTO ${this.quotedSchemaIdentifier}.idempotency_records (key, fingerprint, status, expires_at)
        VALUES ($1, $2, 'processing', $3)`,
-      [key, fingerprint, Date.now() + ttlMs]
-    );
+        [key, fingerprint, Date.now() + ttlMs]
+      );
+    } catch (error) {
+      if (error?.code === "23505") {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/stores/postgres/postgres.test.js
+++ b/packages/stores/postgres/postgres.test.js
@@ -50,3 +50,36 @@ test("PostgresIdempotencyStore - close calls pool.end", async (t) => {
   t.equal(pool.end.calledOnce, true, "pool.end should be called once");
   t.end();
 });
+
+test("PostgresIdempotencyStore - startProcessing on existing key throws IdempotencyKeyExistsError", async (t) => {
+  const { IdempotencyKeyExistsError } = await import("@idempot/core");
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  await store.startProcessing("dup-key", "fp-1", 60000);
+
+  await t.rejects(
+    store.startProcessing("dup-key", "fp-2", 60000),
+    IdempotencyKeyExistsError,
+    "duplicate insert should throw IdempotencyKeyExistsError"
+  );
+
+  await store.close();
+  t.end();
+});
+
+test("PostgresIdempotencyStore - startProcessing propagates non-constraint driver errors", async (t) => {
+  const pool = createFakePgPool();
+  const store = new PostgresIdempotencyStore({ pool });
+
+  pool.__insertError = new Error("connection refused");
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    /connection refused/,
+    "transient driver error should propagate unchanged"
+  );
+
+  await store.close();
+  t.end();
+});

--- a/packages/stores/postgres/tests/pg-test-helpers.js
+++ b/packages/stores/postgres/tests/pg-test-helpers.js
@@ -44,6 +44,11 @@ export function createFakePgPool() {
 
   const pool = {
     __store: store,
+    /**
+     * Optional injected error thrown by INSERT operations.
+     * @type {Error | null}
+     */
+    __insertError: null,
 
     query: sinon.fake(async (sql, params = []) => {
       const parsed = parseSql(sql);
@@ -69,7 +74,19 @@ export function createFakePgPool() {
       }
 
       if (parsed.operation === "INSERT") {
+        if (pool.__insertError) {
+          const injected = pool.__insertError;
+          pool.__insertError = null;
+          throw injected;
+        }
         const [key, fingerprint, expiresAt] = params;
+        if (store.has(key)) {
+          const error = new Error(
+            `duplicate key value violates unique constraint "idempotency_records_pkey"`
+          );
+          error.code = "23505";
+          throw error;
+        }
         store.set(key, {
           key,
           fingerprint,

--- a/packages/stores/sqlite/deno-sqlite.js
+++ b/packages/stores/sqlite/deno-sqlite.js
@@ -17,6 +17,7 @@
 
 // @ts-nocheck - Deno runtime only
 import { DB as Database } from "sqlite";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 export class DenoSqliteIdempotencyStore {
   /** @type {Database} */
@@ -123,10 +124,29 @@ export class DenoSqliteIdempotencyStore {
    * @returns {Promise<void>}
    */
   async startProcessing(key, fingerprint, ttlMs) {
-    this.db.query(
-      `INSERT INTO idempotency_records (key, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
-      [key, fingerprint, Date.now() + ttlMs]
-    );
+    try {
+      this.db.query(
+        `INSERT INTO idempotency_records (key, fingerprint, status, expires_at) VALUES (?, ?, 'processing', ?)`,
+        [key, fingerprint, Date.now() + ttlMs]
+      );
+    } catch (error) {
+      // The deno.land/x/sqlite driver reports code 19 (SQLITE_CONSTRAINT) for
+      // ALL constraint violations, so matching on the code alone would also
+      // translate NOT NULL violations (e.g. a missing fingerprint) into a
+      // false 409. `key` is the only unique constraint, so matching the
+      // "UNIQUE constraint failed" message precisely targets the PK-duplicate
+      // race while letting other constraint errors propagate as 503.
+      const isDuplicateKey =
+        typeof error?.message === "string" &&
+        error.message.includes("UNIQUE constraint failed");
+      if (isDuplicateKey) {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/stores/sqlite/index.js
+++ b/packages/stores/sqlite/index.js
@@ -4,6 +4,7 @@
  */
 
 import Database from "better-sqlite3";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 /**
  * @implements {IdempotencyStore}
@@ -116,15 +117,25 @@ export class SqliteIdempotencyStore {
    * @returns {Promise<void>}
    */
   async startProcessing(key, fingerprint, ttlMs) {
-    this.db
-      .prepare(
-        `
+    try {
+      this.db
+        .prepare(
+          `
       INSERT INTO idempotency_records
       (key, fingerprint, status, expires_at)
       VALUES (?, ?, 'processing', ?)
     `
-      )
-      .run(key, fingerprint, Date.now() + ttlMs);
+        )
+        .run(key, fingerprint, Date.now() + ttlMs);
+    } catch (error) {
+      if (error?.code === "SQLITE_CONSTRAINT_PRIMARYKEY") {
+        throw new IdempotencyKeyExistsError(
+          `Idempotency key already exists: ${key}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/stores/sqlite/sqlite.test.js
+++ b/packages/stores/sqlite/sqlite.test.js
@@ -19,3 +19,34 @@ test("sqlite - creates store with default path when no options provided", (t) =>
   fs.unlinkSync("./idempotency.db");
   t.end();
 });
+
+test("sqlite - startProcessing on existing key throws IdempotencyKeyExistsError", async (t) => {
+  const { IdempotencyKeyExistsError } = await import("@idempot/core");
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+  await store.startProcessing("dup-key", "fp-1", 60000);
+
+  await t.rejects(
+    store.startProcessing("dup-key", "fp-2", 60000),
+    IdempotencyKeyExistsError,
+    "duplicate insert should throw IdempotencyKeyExistsError"
+  );
+
+  store.close();
+  t.end();
+});
+
+test("sqlite - startProcessing propagates non-constraint driver errors", async (t) => {
+  const store = new SqliteIdempotencyStore({ path: ":memory:" });
+
+  // A NOT NULL violation (fingerprint undefined) is a SQLITE_CONSTRAINT_NOTNULL
+  // error, not the PRIMARY KEY constraint; it must propagate unchanged.
+  await t.rejects(
+    store.startProcessing("fresh-key", undefined, 60000),
+    /NOT NULL/,
+    "non-key constraint errors propagate unchanged"
+  );
+
+  store.close();
+  t.end();
+});

--- a/tests/integration/hono-mysql.test.js
+++ b/tests/integration/hono-mysql.test.js
@@ -9,6 +9,8 @@ import {
   createNodeMysqlStore,
   waitForIdempotencyRecordComplete
 } from "./shared/mysql.js";
+import { createLostRaceStore } from "./shared/lost-race-store.js";
+import { generateFingerprint } from "../../packages/core/src/fingerprint.js";
 
 function createHonoMysqlApp(store) {
   const app = new Hono();
@@ -126,5 +128,94 @@ t.test(
     });
 
     t.equal(response2.status, 409, "should return 409 conflict");
+  }
+);
+
+t.test(
+  "Hono + MySQL - lost insert race returns 409 when winner is still processing",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    // Seed the winner's processing record directly on the real store so the
+    // loser's insert hits the real driver's duplicate-key constraint (ER_DUP_ENTRY).
+    await store.startProcessing(key, fp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoMysqlApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "loser should get 409 conflict");
+    t.match(response.body.type, /#section-2\.6$/, "conflict spec reference");
+    t.equal(response.body.retryable, true, "conflict is retryable");
+  }
+);
+
+t.test(
+  "Hono + MySQL - lost race replays 200 when winner already completed",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+    await store.complete(key, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"winner":true}'
+    });
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoMysqlApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 200, "loser gets 200 replay");
+    t.equal(response.body.winner, true, "body is the winner's body");
+    t.equal(response.headers["x-idempotent-replayed"], "true", "replay header");
+  }
+);
+
+t.test(
+  "Hono + MySQL - lost race re-lookup finds no record returns 409 (TTL expiry)",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+
+    // missRecheck: simulate the winner's record having expired (TTL) before
+    // the loser's re-lookup runs -> KTD2 says the loser still gets a 409.
+    const wrapped = createLostRaceStore(store, { missRecheck: true });
+    const app = createHonoMysqlApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "no-record re-lookup returns 409 per KTD2");
+    t.equal(response.body.retryable, true, "conflict is retryable");
   }
 );

--- a/tests/integration/hono-postgres.test.js
+++ b/tests/integration/hono-postgres.test.js
@@ -15,6 +15,9 @@ import {
   createPostgresStore,
   waitForIdempotencyRecordComplete
 } from "./shared/postgres.js";
+import { createLostRaceStore } from "./shared/lost-race-store.js";
+import { generateFingerprint } from "../../packages/core/src/fingerprint.js";
+import { IdempotencyKeyExistsError } from "../../packages/core/src/errors.js";
 
 function createHonoPostgresApp(store) {
   const app = new Hono();
@@ -189,6 +192,123 @@ t.test(
       response2.body.title,
       /already used|different/i,
       "should indicate key is already used"
+    );
+  }
+);
+
+t.test(
+  "Hono + Postgres - lost insert race returns 409 when winner is still processing",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    // Seed the winner's processing record directly on the real store so the
+    // loser's insert hits the real driver's primary-key constraint (23505).
+    await store.startProcessing(key, fp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoPostgresApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "loser should get 409 conflict");
+    t.match(response.body.type, /#section-2\.6$/, "conflict spec reference");
+    t.equal(response.body.retryable, true, "conflict is retryable");
+  }
+);
+
+t.test(
+  "Hono + Postgres - lost race replays 200 when winner already completed",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+    await store.complete(key, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"winner":true}'
+    });
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoPostgresApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 200, "loser gets 200 replay");
+    t.equal(response.body.winner, true, "body is the winner's body");
+    t.equal(response.headers["x-idempotent-replayed"], "true", "replay header");
+  }
+);
+
+t.test(
+  "Hono + Postgres - lost race re-lookup finds no record returns 409 (TTL expiry)",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+
+    // missRecheck: simulate the winner's record having expired (TTL) before
+    // the loser's re-lookup runs -> KTD2 says the loser still gets a 409.
+    const wrapped = createLostRaceStore(store, { missRecheck: true });
+    const app = createHonoPostgresApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "no-record re-lookup returns 409 per KTD2");
+    t.equal(response.body.retryable, true, "conflict is retryable");
+  }
+);
+
+t.test(
+  "Hono + Postgres - two concurrent startProcessing calls on the same key: exactly one wins",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const fp = generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    const results = await Promise.allSettled([
+      store.startProcessing(key, fp, 60000),
+      store.startProcessing(key, fp, 60000)
+    ]);
+
+    // The primary key on `key` guarantees exactly one INSERT commits and the
+    // other hits 23505 -> IdempotencyKeyExistsError, regardless of which
+    // request wins the race.
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+
+    t.equal(fulfilled.length, 1, "exactly one concurrent insert wins");
+    t.equal(rejected.length, 1, "exactly one concurrent insert loses");
+    t.match(
+      rejected[0]?.reason,
+      IdempotencyKeyExistsError,
+      "the loser surfaces IdempotencyKeyExistsError (not a 503-style driver error)"
     );
   }
 );

--- a/tests/integration/hono-sqlite.test.js
+++ b/tests/integration/hono-sqlite.test.js
@@ -4,6 +4,8 @@ import { Hono } from "hono";
 import { idempotency } from "../../packages/frameworks/hono/index.js";
 import { createSqliteStore, cleanupSqlite } from "./shared/sqlite.js";
 import { makeRequest } from "./shared/request.js";
+import { createLostRaceStore } from "./shared/lost-race-store.js";
+import { generateFingerprint } from "../../packages/core/src/fingerprint.js";
 
 function createHonoSqliteApp(store) {
   const app = new Hono();
@@ -131,5 +133,94 @@ t.test(
       1,
       "should only have one order despite two different idempotency keys (same fingerprint)"
     );
+  }
+);
+
+t.test(
+  "Hono + SQLite - lost insert race returns 409 when winner is still processing",
+  async (t) => {
+    const { store } = t.context;
+    const key = "race-key-12345678901234567890";
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    // Seed the winner's processing record directly on the real store so the
+    // loser's insert hits the real driver's primary-key constraint.
+    await store.startProcessing(key, fp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoSqliteApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "loser should get 409 conflict");
+    t.match(response.body.type, /#section-2\.6$/, "conflict spec reference");
+    t.equal(response.body.retryable, true, "conflict is retryable");
+  }
+);
+
+t.test(
+  "Hono + SQLite - lost race replays 200 when winner already completed",
+  async (t) => {
+    const { store } = t.context;
+    const key = "race-complete-key-12345678901";
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+    await store.complete(key, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"winner":true}'
+    });
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoSqliteApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 200, "loser gets 200 replay");
+    t.equal(response.body.winner, true, "body is the winner's body");
+    t.equal(response.headers["x-idempotent-replayed"], "true", "replay header");
+  }
+);
+
+t.test(
+  "Hono + SQLite - lost race re-lookup finds no record returns 409 (TTL expiry)",
+  async (t) => {
+    const { store } = t.context;
+    const key = "race-expired-key-12345678901";
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+
+    // missRecheck: simulate the winner's record having expired (TTL) before
+    // the loser's re-lookup runs -> KTD2 says the loser still gets a 409.
+    const wrapped = createLostRaceStore(store, { missRecheck: true });
+    const app = createHonoSqliteApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "no-record re-lookup returns 409 per KTD2");
+    t.equal(response.body.retryable, true, "conflict is retryable");
   }
 );

--- a/tests/integration/shared/lost-race-store.js
+++ b/tests/integration/shared/lost-race-store.js
@@ -1,0 +1,46 @@
+/**
+ * Thin wrapper around a real idempotency store that simulates the lost-race
+ * interleaving required to exercise the middleware's catch-and-reroute path
+ * deterministically against a real driver:
+ *
+ *   - The FIRST `lookup` misses, as if the loser checked before the winner's
+ *     record was inserted. This routes the loser into `startProcessing`.
+ *   - `startProcessing` delegates to the real store, so a pre-created winner
+ *     record makes the real driver raise its duplicate-key constraint, which
+ *     the store translates to `IdempotencyKeyExistsError`.
+ *   - Subsequent `lookup`s delegate to the real store (the reroute re-lookup),
+ *     unless `missRecheck` is set, in which case the re-lookup also resolves
+ *     null to simulate the winner's record having expired (TTL) before the
+ *     loser re-checked (KTD2: 409).
+ *
+ * All other store operations pass straight through to the underlying store.
+ */
+
+/**
+ * @param {import("@idempot/core").IdempotencyStore} store
+ * @param {{ missRecheck?: boolean }} [options]
+ */
+export function createLostRaceStore(store, { missRecheck = false } = {}) {
+  let lookupCount = 0;
+  return {
+    async lookup(key, fingerprint) {
+      lookupCount += 1;
+      if (lookupCount === 1) {
+        return { byKey: null, byFingerprint: null };
+      }
+      if (missRecheck) {
+        return { byKey: null, byFingerprint: null };
+      }
+      return store.lookup(key, fingerprint);
+    },
+    async startProcessing(key, fingerprint, ttlMs) {
+      return store.startProcessing(key, fingerprint, ttlMs);
+    },
+    async complete(key, response) {
+      return store.complete(key, response);
+    },
+    async close() {
+      return store.close();
+    }
+  };
+}

--- a/tests/integration/shared/postgres.js
+++ b/tests/integration/shared/postgres.js
@@ -21,7 +21,22 @@ export async function createPostgresStore(schema) {
       created_at TIMESTAMP DEFAULT NOW()
     )
   `);
-  return store;
+  // The store constructor fires initSchema() without awaiting it, so the
+  // idempotency_records table may still be in flight. Poll until it exists so
+  // direct store calls in tests don't race the DDL.
+  for (let i = 0; i < 50; i++) {
+    try {
+      await store.pool.query(
+        `SELECT 1 FROM ${quotedSchema}.idempotency_records LIMIT 1`
+      );
+      return store;
+    } catch {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+  throw new Error(
+    `idempotency_records table not ready for schema ${schema} after 1s`
+  );
 }
 
 export async function waitForIdempotencyRecordComplete(

--- a/tests/runtime/bun/bun-sql-integration.test.js
+++ b/tests/runtime/bun/bun-sql-integration.test.js
@@ -3,6 +3,8 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { idempotency } from "../../../packages/frameworks/hono/index.js";
 import { BunSqlIdempotencyStore } from "../../../packages/stores/bun-sql/index.js";
+import { createLostRaceStore } from "../../../tests/integration/shared/lost-race-store.js";
+import { generateFingerprint } from "../../../packages/core/src/fingerprint.js";
 import mysql from "mysql2/promise";
 import { createRequire } from "module";
 import { ulid } from "ulid";
@@ -154,6 +156,83 @@ describe("BunSqlIdempotencyStore with PostgreSQL", () => {
     expect(response1.status).toBe(200);
     expect(response2.status).toBe(200);
     expect(response2.headers["x-idempotent-replayed"]).toBe("true");
+  });
+
+  test("lost insert race returns 409 when winner is still processing", async () => {
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    // Seed the winner's processing record directly on the real bun-sql store
+    // so the loser's insert hits the real driver's primary-key constraint.
+    await store.startProcessing(key, fp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const raceApp = createApp(wrapped);
+    const raceServer = serve({ fetch: raceApp.fetch, port: 0 });
+    await new Promise((resolve) => raceServer.on("listening", resolve));
+    const racePort = raceServer.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    raceServer.close();
+
+    expect(response.status).toBe(409);
+    expect(response.body.type).toMatch(/#section-2\.6$/);
+    expect(response.body.retryable).toBe(true);
+  });
+
+  test("lost race replays 200 when winner already completed", async () => {
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+    await store.complete(key, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"winner":true}'
+    });
+
+    const wrapped = createLostRaceStore(store);
+    const raceApp = createApp(wrapped);
+    const raceServer = serve({ fetch: raceApp.fetch, port: 0 });
+    await new Promise((resolve) => raceServer.on("listening", resolve));
+    const racePort = raceServer.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    raceServer.close();
+
+    expect(response.status).toBe(200);
+    expect(response.body.winner).toBe(true);
+    expect(response.headers["x-idempotent-replayed"]).toBe("true");
+  });
+
+  test("lost race re-lookup finds no record returns 409 (TTL expiry)", async () => {
+    const key = generateIdempotencyKey();
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+
+    // missRecheck: simulate the winner's record having expired (TTL) before
+    // the loser's re-lookup runs -> KTD2 says the loser still gets a 409.
+    const wrapped = createLostRaceStore(store, { missRecheck: true });
+    const raceApp = createApp(wrapped);
+    const raceServer = serve({ fetch: raceApp.fetch, port: 0 });
+    await new Promise((resolve) => raceServer.on("listening", resolve));
+    const racePort = raceServer.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    raceServer.close();
+
+    expect(response.status).toBe(409);
+    expect(response.body.retryable).toBe(true);
   });
 
   test("conflict with same fingerprint different key", async () => {

--- a/tests/runtime/bun/bun-sql.test.js
+++ b/tests/runtime/bun/bun-sql.test.js
@@ -86,6 +86,22 @@ describe("BunSqlIdempotencyStore", () => {
       expect(result.byKey.expiresAt).toBeGreaterThanOrEqual(beforeTime);
       expect(result.byKey.expiresAt).toBeLessThanOrEqual(afterTime);
     });
+
+    test("throws IdempotencyKeyExistsError on duplicate key", async () => {
+      await store.startProcessing("dup-key", "fp1", 60000);
+
+      await expect(
+        store.startProcessing("dup-key", "fp2", 60000)
+      ).rejects.toThrow("Idempotency key already exists: dup-key");
+    });
+
+    test("propagates non-constraint driver errors unchanged", async () => {
+      // A NOT NULL violation (fingerprint undefined) is not a duplicate-key
+      // constraint; it must propagate rather than be translated to 409.
+      await expect(
+        store.startProcessing("fresh-key", undefined, 60000)
+      ).rejects.toThrow(/NOT NULL/);
+    });
   });
 
   describe("complete", () => {

--- a/tests/runtime/deno/mysql-test-helpers.js
+++ b/tests/runtime/deno/mysql-test-helpers.js
@@ -40,6 +40,9 @@ export function createFakeMysqlClient(sharedStore) {
 
       if (normalized.startsWith("INSERT")) {
         const [key, fingerprint, expiresAt] = params;
+        if (store.has(key)) {
+          throw new Error(`Duplicate entry '${key}' for key 'PRIMARY'`);
+        }
         store.set(key, {
           key,
           fingerprint,

--- a/tests/runtime/deno/mysql.test.js
+++ b/tests/runtime/deno/mysql.test.js
@@ -1,5 +1,9 @@
-import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  assertEquals,
+  assertRejects
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { MysqlIdempotencyStore } from "../../../packages/stores/mysql/deno-mysql.js";
+import { IdempotencyKeyExistsError } from "../../../packages/core/src/errors.js";
 import { createFakeMysqlClient } from "./mysql-test-helpers.js";
 
 Deno.test(
@@ -23,6 +27,81 @@ Deno.test(
     const completed = await store.lookup("key1", "fingerprint1");
     assertEquals(completed.byKey?.status, "complete");
     assertEquals(completed.byKey?.response?.status, 200);
+
+    await store.close();
+  }
+);
+
+Deno.test(
+  "MysqlIdempotencyStore (Deno) startProcessing throws IdempotencyKeyExistsError on duplicate key",
+  async () => {
+    const client = createFakeMysqlClient();
+    const store = new MysqlIdempotencyStore({});
+    store.client = client;
+
+    await store.startProcessing("dup-key", "fingerprint1", 60000);
+
+    await assertRejects(
+      () => store.startProcessing("dup-key", "fingerprint2", 60000),
+      IdempotencyKeyExistsError
+    );
+
+    await store.close();
+  }
+);
+
+Deno.test(
+  "MysqlIdempotencyStore (Deno) translates driver ER_DUP_ENTRY code to IdempotencyKeyExistsError",
+  async () => {
+    const client = createFakeMysqlClient();
+    const store = new MysqlIdempotencyStore({});
+    store.client = client;
+
+    // Override execute to throw a coded duplicate error whose message does NOT
+    // contain the "Duplicate entry" substring, so only the code branch matches.
+    const originalExecute = client.execute.bind(client);
+    client.execute = async (sql, params = []) => {
+      if (sql.trim().toUpperCase().startsWith("INSERT")) {
+        const err = new Error("some other driver message");
+        err.code = "ER_DUP_ENTRY";
+        throw err;
+      }
+      return originalExecute(sql, params);
+    };
+
+    await assertRejects(
+      () => store.startProcessing("any-key", "fp", 60000),
+      IdempotencyKeyExistsError
+    );
+
+    await store.close();
+  }
+);
+
+Deno.test(
+  "MysqlIdempotencyStore (Deno) propagates non-duplicate errors unchanged",
+  async () => {
+    const client = createFakeMysqlClient();
+    const store = new MysqlIdempotencyStore({});
+    store.client = client;
+
+    const originalExecute = client.execute.bind(client);
+    client.execute = async (sql, params = []) => {
+      if (sql.trim().toUpperCase().startsWith("INSERT")) {
+        const err = new Error("connection reset");
+        err.code = "ECONNRESET";
+        throw err;
+      }
+      return originalExecute(sql, params);
+    };
+
+    try {
+      await store.startProcessing("any-key", "fp", 60000);
+      throw new Error("Should have thrown");
+    } catch (e) {
+      assertEquals(e instanceof IdempotencyKeyExistsError, false);
+      assertEquals(e.code, "ECONNRESET");
+    }
 
     await store.close();
   }

--- a/tests/runtime/deno/sqlite.test.js
+++ b/tests/runtime/deno/sqlite.test.js
@@ -1,5 +1,29 @@
-import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  assertEquals,
+  assertRejects
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { DenoSqliteIdempotencyStore } from "../../../packages/stores/sqlite/deno-sqlite.js";
+import { IdempotencyKeyExistsError } from "../../../packages/core/src/errors.js";
+
+Deno.test(
+  "DenoSqliteIdempotencyStore startProcessing propagates non-constraint driver errors unchanged",
+  async () => {
+    const store = new DenoSqliteIdempotencyStore({ path: ":memory:" });
+
+    // A NOT NULL violation (fingerprint undefined) is a constraint error with
+    // the same driver code (19) as a duplicate key, so it must not be
+    // translated into IdempotencyKeyExistsError.
+    try {
+      await store.startProcessing("fresh-key", undefined, 60000);
+      throw new Error("Should have thrown");
+    } catch (e) {
+      assertEquals(e instanceof IdempotencyKeyExistsError, false);
+      assertEquals(e.message.includes("NOT NULL"), true);
+    }
+
+    store.close();
+  }
+);
 
 Deno.test(
   "DenoSqliteIdempotencyStore can start and complete processing",
@@ -20,6 +44,22 @@ Deno.test(
     const completed = await store.lookup("key1", "fingerprint1");
     assertEquals(completed.byKey?.status, "complete");
     assertEquals(completed.byKey?.response?.status, 200);
+
+    store.close();
+  }
+);
+
+Deno.test(
+  "DenoSqliteIdempotencyStore startProcessing throws IdempotencyKeyExistsError on duplicate key",
+  async () => {
+    const store = new DenoSqliteIdempotencyStore({ path: ":memory:" });
+
+    await store.startProcessing("dup-key", "fingerprint1", 60000);
+
+    await assertRejects(
+      () => store.startProcessing("dup-key", "fingerprint2", 60000),
+      IdempotencyKeyExistsError
+    );
 
     store.close();
   }


### PR DESCRIPTION
## Summary

Fixes #181.

When two requests race on the same Idempotency-Key and the loser's initial lookup misses (the winner hasn't committed yet), but the winner then wins and the loser hits a duplicate-key integrity error, the loser previously returned **503**. This PR makes the loser re-check the store and return a spec-compliant **409** (winner still processing) or **200** (winner complete / replay).

Scope is SQL stores only (postgres, sqlite, mysql, bun-sql). Redis behaves differently (silently overwrites instead of raising integrity errors) and is tracked separately in **#182**.

## What changed

- **core**: new `IdempotencyKeyExistsError` (+ `cause` preservation of the original driver error); `withResilience` retry predicate and opossum `errorFilter` short-circuit on it (no retry storm, breaker stays closed on a contested key). New exported `IDEMPOTENCY_KEY_PROCESSING_MESSAGE` constant.
- **stores**: postgres (code `23505`), sqlite / better-sqlite3 (`SQLITE_CONSTRAINT_PRIMARYKEY`), mysql (`ER_DUP_ENTRY` / message), bun-sql — duplicate-key integrity errors are translated to `IdempotencyKeyExistsError`. Deno store variants import via `@idempot/core` (+ `deno.json` import map) instead of a relative path that broke the published JSR artifact.
- **frameworks**: hono, fastify, express, bun middlewares catch `IdempotencyKeyExistsError`, re-lookup, and return 409 (processing) / 200 (replay) / 409 (record vanished / TTL, per KTD2). Framework duplication deliberately preserved (settled decision KTD5); the shared race-stub store and conflict-message constant were extracted.
- **tests**: deterministic SQL race tests (via `lost-race-store.js` / `race-store-helper.js`) for hono-sqlite/postgres/mysql and bun-sql postgres; passthrough + `ER_DUP_ENTRY` code-branch coverage in bun-sql and deno-mysql.

## Verification

- `pnpm test` (tap): pass
- `pnpm run test:verify-coverage-min` (100/100/100/100): pass
- `pnpm lint`: pass
- `prettier` on changed files: pass
- `bun test tests/runtime/bun/`: 30 pass
- `deno test` (sqlite + mysql): 11 pass

## Known Residuals

Accepted and not fixed in this PR (deliberate / out-of-scope):

- **P3 advisory — no-record re-lookup returns "already being processed" 409** (`packages/frameworks/hono/index.js` ~L215). When the winner's record TTL-expires between the loser's duplicate-key error and its re-lookup, the 409 body reuses `IDEMPOTENCY_KEY_PROCESSING_MESSAGE`, which misstates that something is still processing. KTD2-compliant and self-heals on client retry. Optionally introduce a distinct message/constant later.
- **P3 advisory — re-lookup `catch {}` swallows the store error** (`packages/frameworks/hono/index.js` ~L177). A genuine store failure during the re-lookup yields a bare 503 with no logging to distinguish it from a TTL-expiry 409. Mirrors a pre-existing pattern in the normal path. Optional: log before returning 503.
- **Deliberate no-fix — code-only duplicate detection in postgres/better-sqlite3** kept. node-pg and better-sqlite3 set `.code` reliably; adding message-substring fallbacks (as mysql/deno-sqlite/bun-sql have) would increase false-positive translation risk. Different drivers may therefore classify differently — acceptable and documented.

## Related follow-up issues (filed from review of this PR)

- **#183** — conflict recheck returns 409 before 422 on fingerprint-mismatched concurrent winner (pre-existing ordering)
- **#184** — single-flight coalescing for concurrent same-key requests (removed breaker backstop on collision storms)
- **#185** — write-op retry blurs indeterminate commit into false 409 conflict

## Post-Deploy Monitoring & Validation

Low-risk behavioural fix with no new public-surface monitoring requirements beyond normal idempotency health checks. Watch:

- **Signals:** request volume by idempotency key; share of duplicate-key errors translated correctly (no unexpected 503s on concurrent same-key traffic); no breaker trips attributable to contested keys (should stay closed).
- **Look for:** the `IdempotencyKeyExistsError` path returning 409/200 as intended; no regression to 503 for genuine transient store failures.
- **Failure trigger / rollback:** if 503s spike on concurrent same-key traffic or a store translation regresses (missing driver variant), the error escapes as a plain Error and reverts to old behaviour; rollback is a revert of this PR.
- **Validation window:** one release cycle; owner: library maintainers.
