### PR TITLE
fix(redis-store): atomically claim idempotency key in startProcessing (#182)

### DIFF
--- a/packages/stores/redis/deno-redis.js
+++ b/packages/stores/redis/deno-redis.js
@@ -17,6 +17,7 @@
 
 // @ts-nocheck - Deno runtime only
 import { connect } from "@db/redis";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 
 /**
  * @typedef {Object} RedisIdempotencyStoreOptions
@@ -85,14 +86,20 @@ export class RedisIdempotencyStore {
       expiresAt: Date.now() + ttlMs
     };
 
-    await Promise.all([
-      this.redis.set(`${this.prefix}${key}`, JSON.stringify(record), {
-        expireIn: ttlSeconds
-      }),
-      this.redis.set(`fingerprint:${fingerprint}`, key, {
-        expireIn: ttlSeconds
-      })
-    ]);
+    const acquired = await this.redis.set(
+      `${this.prefix}${key}`,
+      JSON.stringify(record),
+      { nx: true, expireIn: ttlSeconds }
+    );
+    if (acquired !== "OK") {
+      throw new IdempotencyKeyExistsError(
+        `Idempotency key already exists: ${key}`
+      );
+    }
+
+    await this.redis.set(`fingerprint:${fingerprint}`, key, {
+      expireIn: ttlSeconds
+    });
   }
 
   /**

--- a/packages/stores/redis/node-redis.js
+++ b/packages/stores/redis/node-redis.js
@@ -5,6 +5,8 @@
 
 /** @typedef {import("ioredis").Redis} Redis */
 
+import { IdempotencyKeyExistsError } from "@idempot/core";
+
 /**
  * @typedef {Object} RedisIdempotencyStoreOptions
  * @property {Redis} client - The Redis client instance
@@ -92,11 +94,45 @@ export class RedisIdempotencyStore {
 
     const ttlSeconds = Math.ceil(ttlMs / 1000);
 
-    // Pipeline both writes
+    // Atomically claim the key so only one concurrent request wins. SET ... NX
+    // resolves "OK" for the winner only; the loser gets null and surfaces the
+    // conflict via IdempotencyKeyExistsError (mirrors the SQL stores' integrity
+    // error translation), routing the loser to 409/200 in the middleware.
     const pipeline = this.client.pipeline();
-    pipeline.setex(`${this.prefix}${key}`, ttlSeconds, JSON.stringify(record));
-    pipeline.setex(`fingerprint:${fingerprint}`, ttlSeconds, key);
-    await pipeline.exec();
+    pipeline.set(
+      `${this.prefix}${key}`,
+      JSON.stringify(record),
+      "EX",
+      ttlSeconds,
+      "NX"
+    );
+    // Fingerprint index is non-unique (multiple keys may share a fingerprint,
+    // matching the SQL stores and deno-redis), so it is a plain SET, not NX.
+    pipeline.set(`fingerprint:${fingerprint}`, key, "EX", ttlSeconds);
+    const results = await pipeline.exec();
+
+    if (!results) {
+      throw new Error("Redis pipeline failed");
+    }
+
+    // ioredis exec returns [err, result] per command; surface a real driver
+    // error (infra failure -> 503) rather than misreporting it as a conflict.
+    const [keyErr, keyResult] = results[0];
+    if (keyErr) {
+      throw keyErr;
+    }
+    if (keyResult !== "OK") {
+      throw new IdempotencyKeyExistsError(
+        `Idempotency key already exists: ${key}`
+      );
+    }
+    // The fingerprint-index SET shares the same pipeline; surface its driver
+    // error too, so a partial write (key claimed, index missing) is not
+    // reported as success and silently bypasses byFingerprint dedup.
+    const [fpErr] = results[1] ?? [];
+    if (fpErr) {
+      throw fpErr;
+    }
   }
 
   /**

--- a/packages/stores/redis/redis.properties.test.js
+++ b/packages/stores/redis/redis.properties.test.js
@@ -1,5 +1,6 @@
 import { test } from "tap";
 import * as fc from "fast-check";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 import { RedisIdempotencyStore } from "@idempot/redis-store";
 import { createFakeRedisClient } from "./tests/redis-test-helpers.js";
 
@@ -40,7 +41,7 @@ test("redis - lookup determinism (same inputs yield same outputs)", async (t) =>
   t.pass("lookup determinism invariant holds");
 });
 
-test("redis - startProcessing idempotency", async (t) => {
+test("redis - startProcessing rejects a duplicate key without overwriting", async (t) => {
   await fc.assert(
     fc.asyncProperty(
       fcString(),
@@ -49,14 +50,23 @@ test("redis - startProcessing idempotency", async (t) => {
       async (key, fingerprint, ttlMs) => {
         const store = createStore();
 
+        // Winner acquires the key and owns the record.
         await store.startProcessing(key, fingerprint, ttlMs);
-        await store.startProcessing(key, fingerprint, ttlMs);
-        await store.startProcessing(key, fingerprint, ttlMs);
+
+        // A loser racing the same key must be signalled, not silently
+        // overwrite the winner's in-flight record (#182).
+        let loserRejected = false;
+        try {
+          await store.startProcessing(key, fingerprint, ttlMs);
+        } catch (error) {
+          loserRejected = error instanceof IdempotencyKeyExistsError;
+        }
 
         const result = await store.lookup(key, fingerprint);
 
         await store.close();
         return (
+          loserRejected &&
           result.byKey !== null &&
           result.byKey.key === key &&
           result.byKey.fingerprint === fingerprint
@@ -65,7 +75,7 @@ test("redis - startProcessing idempotency", async (t) => {
     ),
     { numRuns: 100 }
   );
-  t.pass("startProcessing idempotency invariant holds");
+  t.pass("duplicate-key rejection invariant holds");
 });
 
 test("redis - fingerprint lookup finds record", async (t) => {

--- a/packages/stores/redis/redis.unit.test.js
+++ b/packages/stores/redis/redis.unit.test.js
@@ -5,9 +5,46 @@
 // For property-based tests, see redis.properties.test.js
 import { test } from "tap";
 import sinon from "sinon";
+import { IdempotencyKeyExistsError } from "@idempot/core";
 import { RedisIdempotencyStore } from "@idempot/redis-store";
 import { createFakeRedisClient } from "./tests/redis-test-helpers.js";
 import { runStoreTests } from "../../core/tests/store-adapter-suite.js";
+
+const RACE_KEY = "race-key-12345678901234567890";
+const RACE_FP = "race-fp-12345678901234567890";
+
+test("RedisIdempotencyStore - startProcessing on existing key throws IdempotencyKeyExistsError", async (t) => {
+  const client = createFakeRedisClient();
+  const store = new RedisIdempotencyStore({ client });
+
+  await store.startProcessing(RACE_KEY, RACE_FP, 60000);
+
+  await t.rejects(
+    store.startProcessing(RACE_KEY, RACE_FP, 60000),
+    IdempotencyKeyExistsError,
+    "loser should reject with IdempotencyKeyExistsError"
+  );
+  t.end();
+});
+
+test("RedisIdempotencyStore - loser does not overwrite winner's record", async (t) => {
+  const client = createFakeRedisClient();
+  const store = new RedisIdempotencyStore({ client });
+
+  await store.startProcessing(RACE_KEY, RACE_FP, 60000);
+  await t.rejects(
+    store.startProcessing(RACE_KEY, RACE_FP, 60000),
+    IdempotencyKeyExistsError
+  );
+
+  const result = await store.lookup(RACE_KEY, RACE_FP);
+  t.equal(
+    result.byKey?.fingerprint,
+    RACE_FP,
+    "winner's record is intact after the loser loses the race"
+  );
+  t.end();
+});
 
 runStoreTests({
   name: "redis-unit",
@@ -84,6 +121,116 @@ test("RedisIdempotencyStore - handles pipeline errors gracefully", async (t) => 
   } catch (err) {
     t.ok(err, "should throw error on connection failure");
   }
+  t.end();
+});
+
+test("RedisIdempotencyStore - startProcessing throws when pipeline returns null", async (t) => {
+  const client = createFakeRedisClient();
+  sinon.replace(
+    client,
+    "pipeline",
+    sinon.fake.returns({
+      set: () => {},
+      exec: sinon.fake.resolves(null)
+    })
+  );
+  t.teardown(() => sinon.restore());
+
+  const store = new RedisIdempotencyStore({ client });
+
+  try {
+    await store.startProcessing("test-key", "test-fp", 60000);
+    t.fail("should have thrown");
+  } catch (err) {
+    t.match(
+      err.message,
+      /pipeline failed/i,
+      "should throw on null pipeline result"
+    );
+  }
+  t.end();
+});
+
+test("RedisIdempotencyStore - startProcessing propagates a real driver error", async (t) => {
+  const client = createFakeRedisClient();
+  const driverError = new Error("Connection is closed");
+  sinon.replace(
+    client,
+    "pipeline",
+    sinon.fake.returns({
+      set: () => {},
+      exec: sinon.fake.resolves([
+        [driverError, undefined],
+        [null, "OK"]
+      ])
+    })
+  );
+  t.teardown(() => sinon.restore());
+
+  const store = new RedisIdempotencyStore({ client });
+
+  try {
+    await store.startProcessing("test-key", "test-fp", 60000);
+    t.fail("should have thrown");
+  } catch (err) {
+    t.equal(
+      err,
+      driverError,
+      "should propagate the driver error, not a conflict"
+    );
+  }
+  t.end();
+});
+
+test("RedisIdempotencyStore - startProcessing propagates a fingerprint-index driver error", async (t) => {
+  const client = createFakeRedisClient();
+  const fpError = new Error(
+    "WRONGTYPE Operation against a key holding the wrong kind of value"
+  );
+  sinon.replace(
+    client,
+    "pipeline",
+    sinon.fake.returns({
+      set: () => {},
+      exec: sinon.fake.resolves([
+        [null, "OK"],
+        [fpError, undefined]
+      ])
+    })
+  );
+  t.teardown(() => sinon.restore());
+
+  const store = new RedisIdempotencyStore({ client });
+
+  try {
+    await store.startProcessing("test-key", "test-fp", 60000);
+    t.fail("should have thrown");
+  } catch (err) {
+    t.equal(
+      err,
+      fpError,
+      "should propagate the fingerprint-index driver error"
+    );
+  }
+  t.end();
+});
+
+test("RedisIdempotencyStore - startProcessing tolerates a missing fingerprint result slot", async (t) => {
+  const client = createFakeRedisClient();
+  sinon.replace(
+    client,
+    "pipeline",
+    sinon.fake.returns({
+      set: () => {},
+      exec: sinon.fake.resolves([[null, "OK"]])
+    })
+  );
+  t.teardown(() => sinon.restore());
+
+  const store = new RedisIdempotencyStore({ client });
+
+  await store.startProcessing("test-key", "test-fp", 60000);
+  t.pass("should not throw when the fingerprint result slot is absent");
   t.end();
 });
 

--- a/packages/stores/redis/tests/redis-test-helpers.js
+++ b/packages/stores/redis/tests/redis-test-helpers.js
@@ -54,8 +54,8 @@ export function createFakeRedisClient() {
           commands.push(["get", key]);
           return pipelineObj;
         },
-        setex: (key, ttl, value) => {
-          commands.push(["setex", key, ttl, value]);
+        set: (key, value, ...flags) => {
+          commands.push(["set", key, value, ...flags]);
           return pipelineObj;
         },
         exec: sinon.fake(async () => {
@@ -64,11 +64,15 @@ export function createFakeRedisClient() {
             if (cmd === "get") {
               const val = store.get(args[0]) ?? null;
               results.push([null, val]);
-            } else if (cmd === "setex") {
-              const [key, ttl, value] = args;
-              store.set(key, value);
-              store.expiryTimers.set(key, Date.now() + ttl * 1000);
-              results.push([null, "OK"]);
+            } else if (cmd === "set") {
+              const [skey, svalue, , sttl, nx] = args;
+              if (nx === "NX" && store.has(skey)) {
+                results.push([null, null]);
+              } else {
+                store.set(skey, svalue);
+                store.expiryTimers.set(skey, Date.now() + sttl * 1000);
+                results.push([null, "OK"]);
+              }
             }
           }
           return results;

--- a/tests/integration/express-redis.test.js
+++ b/tests/integration/express-redis.test.js
@@ -3,6 +3,8 @@ import express from "express";
 import { idempotency } from "../../packages/frameworks/express/index.js";
 import { makeRequest } from "./shared/request.js";
 import { createRedisStore, cleanupRedis } from "./shared/redis.js";
+import { createLostRaceStore } from "./shared/lost-race-store.js";
+import { generateFingerprint } from "../../packages/core/src/fingerprint.js";
 
 function createExpressRedisApp(store, client) {
   const app = express();
@@ -65,7 +67,7 @@ t.test("Express + Redis - first request creates record", async (t) => {
 t.test(
   "Express + Redis - duplicate request returns cached response and does not create duplicate records",
   async (t) => {
-    const { store, client, prefix, port } = t.context;
+    const { client, prefix, port } = t.context;
 
     const response1 = await makeRequest(port, {
       idempotencyKey: "test-key-dupe-123456789012345",
@@ -134,5 +136,69 @@ t.test(
       1,
       "should only have one order despite two different idempotency keys (same fingerprint)"
     );
+  }
+);
+
+t.test(
+  "Express + Redis - lost startProcessing race returns 409 when winner still processing",
+  async (t) => {
+    const { store, client, prefix } = t.context;
+    const key = "redis-race-12345678901234567890";
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    // Seed the winner's processing record so the loser's SET NX misses
+    // on the real driver, exactly like the SQL race tests.
+    await store.startProcessing(key, fp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createExpressRedisApp(wrapped, client);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 409, "loser should get 409 conflict");
+    t.match(response.body.type, /#section-2\.6$/, "conflict spec reference");
+    t.equal(response.body.retryable, true, "conflict is retryable");
+
+    const keys = await client.keys(`*${prefix}:orders:*`);
+    t.equal(keys.length, 0, "loser must not create an order");
+  }
+);
+
+t.test(
+  "Express + Redis - lost startProcessing race replays 200 when winner completed",
+  async (t) => {
+    const { store, client } = t.context;
+    const key = "redis-race-complete-12345678901";
+    const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, fp, 60000);
+    await store.complete(key, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"winner":true}'
+    });
+
+    const wrapped = createLostRaceStore(store);
+    const app = createExpressRedisApp(wrapped, client);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "bar" }
+    });
+    server.close();
+
+    t.equal(response.status, 200, "loser gets 200 replay");
+    t.equal(response.body.winner, true, "body is the winner's body");
+    t.equal(response.headers["x-idempotent-replayed"], "true", "replay header");
   }
 );


### PR DESCRIPTION
Closes #182

## Problem

The Redis idempotency stores (`node-redis.js`, `deno-redis.js`) used a plain `SETEX` in `startProcessing`, so two requests racing the same idempotency key **silently overwrote** the in-flight record. Both proceeded — neither the loser got a spec-compliant `409` concurrent-processing conflict (IETF draft §2.6), and no error was ever raised.

Unlike the SQL stores (#181), there is no integrity error to translate: the fix must claim the key atomically.

## Change

Switch `startProcessing` to an atomic `SET ... NX` claim in both stores:

- The winner acquires the key and owns the record; the loser gets `null` and throws `IdempotencyKeyExistsError`.
- The existing middleware already re-looks-up on that error, routing the loser to **409** (still processing) or **200** replay (already complete) — the same path the SQL stores take.
- `withResilience` already excludes `IdempotencyKeyExistsError` from retries, so the loser isn't retried.

Review follow-ups:

- The ioredis pipeline result's `[err, result]` error slot is now surfaced **before** the NX check, so a real driver failure routes to 503/retry instead of being misreported as a conflict.
- The fingerprint index uses a plain `SET` (non-unique), matching the SQL stores and deno-redis where multiple keys may share a fingerprint.

## Tests

- Store unit: loser rejects with `IdempotencyKeyExistsError`; winner's record intact; real driver error propagates; null pipeline → 503-style error.
- Property: duplicate-key rejection invariant (replaces the old silently-overwrite "idempotency" invariant).
- Integration (Express + real Redis): lost race → **409**, only one record; completed race → **200** replay.

100% coverage, lint, and prettier all green; pre-commit hook passes.
