### PR TITLE
ci(release): disable redundant per-issue release comments

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -33,6 +33,12 @@ export default {
         message: "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        successComment: false,
+        releasedLabels: false
+      }
+    ]
   ]
 };


### PR DESCRIPTION
The release workflow ran `@semantic-release/github`'s default success step once per package, commenting and labeling every linked issue and PR across the commit range — 10× over the same issue set, throttling the Release job to ~24 minutes. Disabling that commenting and labeling cuts the job to about a minute; tags, npm publish with provenance, and GitHub Releases are unchanged.

Session-settled decisions carried from planning: suppress issue/PR notifications entirely over one-issue-one-package (user-directed).

Validation: the updated config parses and loads cleanly; the effect is observable on the next release run.

## Documentation

The two options being disabled are both `@semantic-release/github` plugin options, which you can trade up to true/default or templated values if you want scoped notifications later:

- `successComment` — the comment body added to each issue/PR resolved by the release; `false` disables it: https://github.com/semantic-release/github#successcomment
- `releasedLabels` — the labels added to each issue/PR resolved by the release; `false` disables it: https://github.com/semantic-release/github#releasedlabels

Full plugin reference: https://github.com/semantic-release/github#readme
