### PR TITLE
ci(release): load release config as CommonJS

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 /** @type {import('semantic-release').GlobalConfig} */
-export default {
+module.exports = {
   branches: ["main"],
   plugins: [
     [
@@ -36,7 +36,7 @@ export default {
     [
       "@semantic-release/github",
       {
-        successComment: false,
+        successCommentCondition: false,
         releasedLabels: false
       }
     ]


### PR DESCRIPTION
## Problem

Release runs still post `@semantic-release/github` comments on every linked PR/issue and add the `released` label, despite PR #188 adding `successComment: false` / `releasedLabels: false` to `release.config.js`.

The config was never actually loaded. `release.config.js` is ESM (`export default`), and both `multi-semantic-release` and `semantic-release` resolve config per package with `cwd` set to each `packages/*` subdirectory:

- multi-semantic-release's loader (cosmiconfig v7) finds the root file but returns the ESM module nested under `.default`, so its resolved options carry no top-level `plugins`.
- semantic-release's loader (cosmiconfig v9) uses `searchStrategy: 'none'`, so it never climbs from a package subdirectory to the root config.

Result: every release runs with semantic-release's built-in defaults — default GitHub plugin (comments + `released` label), no `@semantic-release/git` release commit, default branches.

## Fix

Convert the config to CommonJS so multi-semantic-release's loader returns it as a plain object with top-level `plugins`, which semantic-release then merges in. Rename `release.config.js` → `release.config.cjs`, use `module.exports`, and switch to `successCommentCondition: false` (non-deprecated way to disable comments) alongside `releasedLabels: false`.

Verified against the locked deps that the resolved GitHub plugin config is now `["@semantic-release/github", {"successCommentCondition":false,"releasedLabels":false}]`.

Next release should log "Skip commenting on issues and pull requests." instead of posting comments/labels, and produce a `chore(release): X.Y.Z [skip ci]` commit from `@semantic-release/git`.