### PR TITLE
fix(core): return 422 over 409 when key reused with different payload (#183)

### DIFF
--- a/packages/core/src/validation.js
+++ b/packages/core/src/validation.js
@@ -316,6 +316,14 @@ export function validateIdempotencyKey(key, options = {}) {
  * @returns {{conflict: boolean, status?: number, error?: string}}
  */
 export function checkLookupConflicts(lookup, key, fingerprint) {
+  if (lookup.byKey && lookup.byKey.fingerprint !== fingerprint) {
+    return {
+      conflict: true,
+      status: 422,
+      error: "Idempotency key reused with different request payload"
+    };
+  }
+
   if (lookup.byKey?.status === "processing") {
     return {
       conflict: true,
@@ -330,14 +338,6 @@ export function checkLookupConflicts(lookup, key, fingerprint) {
       status: 409,
       error:
         "This request was already processed with a different idempotency key"
-    };
-  }
-
-  if (lookup.byKey && lookup.byKey.fingerprint !== fingerprint) {
-    return {
-      conflict: true,
-      status: 422,
-      error: "Idempotency key reused with different request payload"
     };
   }
 

--- a/packages/core/tests/framework-adapter-suite.js
+++ b/packages/core/tests/framework-adapter-suite.js
@@ -1,4 +1,5 @@
 import { test } from "tap";
+import { generateFingerprint } from "../src/fingerprint.js";
 
 /**
  * Validates adapter interface
@@ -303,8 +304,12 @@ export function runAdapterTests(adapter) {
     const store = adapter.createStore();
     const { mount, request, teardown } = await adapter.setup();
 
-    // Pre-populate store with "processing" state
-    const fingerprint = "test-fingerprint-123";
+    // Pre-populate store with "processing" state for the SAME payload the
+    // request will send, so it is a same-payload retry (-> 409), not a
+    // fingerprint-mismatch (which would be -> 422).
+    const fingerprint = await generateFingerprint(
+      JSON.stringify({ foo: "bar" })
+    );
     await store.startProcessing(
       "concurrent-key-12345678901",
       fingerprint,

--- a/packages/core/tests/validation.test.js
+++ b/packages/core/tests/validation.test.js
@@ -150,13 +150,25 @@ test("checkLookupConflicts - no conflicts when lookup is empty", (t) => {
 
 test("checkLookupConflicts - detects processing conflict", (t) => {
   const lookup = {
-    byKey: { status: "processing" },
+    byKey: { status: "processing", fingerprint: "fp" },
     byFingerprint: null
   };
   const result = checkLookupConflicts(lookup, "key", "fp");
   t.equal(result.conflict, true);
   t.equal(result.status, 409);
   t.match(result.error, /already being processed/i);
+  t.end();
+});
+
+test("checkLookupConflicts - 422 wins over 409 when processing record has different payload", (t) => {
+  const lookup = {
+    byKey: { status: "processing", fingerprint: "winner-fp" },
+    byFingerprint: null
+  };
+  const result = checkLookupConflicts(lookup, "key", "loser-fp");
+  t.equal(result.conflict, true);
+  t.equal(result.status, 422);
+  t.match(result.error, /different request payload/i);
   t.end();
 });
 

--- a/tests/integration/express-redis.test.js
+++ b/tests/integration/express-redis.test.js
@@ -172,6 +172,36 @@ t.test(
 );
 
 t.test(
+  "Express + Redis - lost race with different payload returns 422",
+  async (t) => {
+    const { store, client, prefix } = t.context;
+    const key = "redis-race-12345678901234567890";
+    const winnerFp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, winnerFp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createExpressRedisApp(wrapped, client);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+    server.close();
+
+    t.equal(response.status, 422, "loser should get 422 unprocessable");
+    t.match(response.body.type, /#section-2\.2$/, "422 spec reference");
+    t.equal(response.body.retryable, false, "422 is not retryable");
+
+    const keys = await client.keys(`*${prefix}:orders:*`);
+    t.equal(keys.length, 0, "loser must not create an order");
+  }
+);
+
+t.test(
   "Express + Redis - lost startProcessing race replays 200 when winner completed",
   async (t) => {
     const { store, client } = t.context;

--- a/tests/integration/hono-mysql.test.js
+++ b/tests/integration/hono-mysql.test.js
@@ -161,6 +161,33 @@ t.test(
 );
 
 t.test(
+  "Hono + MySQL - lost race with different payload returns 422",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const winnerFp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, winnerFp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoMysqlApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+    server.close();
+
+    t.equal(response.status, 422, "loser should get 422 unprocessable");
+    t.match(response.body.type, /#section-2\.2$/, "422 spec reference");
+    t.equal(response.body.retryable, false, "422 is not retryable");
+  }
+);
+
+t.test(
   "Hono + MySQL - lost race replays 200 when winner already completed",
   async (t) => {
     const { store } = t.context;

--- a/tests/integration/hono-postgres.test.js
+++ b/tests/integration/hono-postgres.test.js
@@ -226,6 +226,33 @@ t.test(
 );
 
 t.test(
+  "Hono + Postgres - lost race with different payload returns 422",
+  async (t) => {
+    const { store } = t.context;
+    const key = generateIdempotencyKey();
+    const winnerFp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, winnerFp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoPostgresApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+    server.close();
+
+    t.equal(response.status, 422, "loser should get 422 unprocessable");
+    t.match(response.body.type, /#section-2\.2$/, "422 spec reference");
+    t.equal(response.body.retryable, false, "422 is not retryable");
+  }
+);
+
+t.test(
   "Hono + Postgres - lost race replays 200 when winner already completed",
   async (t) => {
     const { store } = t.context;

--- a/tests/integration/hono-sqlite.test.js
+++ b/tests/integration/hono-sqlite.test.js
@@ -166,6 +166,33 @@ t.test(
 );
 
 t.test(
+  "Hono + SQLite - lost race with different payload returns 422",
+  async (t) => {
+    const { store } = t.context;
+    const key = "race-key-12345678901234567890";
+    const winnerFp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, winnerFp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const app = createHonoSqliteApp(wrapped);
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const racePort = server.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+    server.close();
+
+    t.equal(response.status, 422, "loser should get 422 unprocessable");
+    t.match(response.body.type, /#section-2\.2$/, "422 spec reference");
+    t.equal(response.body.retryable, false, "422 is not retryable");
+  }
+);
+
+t.test(
   "Hono + SQLite - lost race replays 200 when winner already completed",
   async (t) => {
     const { store } = t.context;

--- a/tests/runtime/bun/bun-sql-integration.test.js
+++ b/tests/runtime/bun/bun-sql-integration.test.js
@@ -183,6 +183,29 @@ describe("BunSqlIdempotencyStore with PostgreSQL", () => {
     expect(response.body.retryable).toBe(true);
   });
 
+  test("lost race with different payload returns 422", async () => {
+    const key = generateIdempotencyKey();
+    const winnerFp = await generateFingerprint(JSON.stringify({ foo: "bar" }));
+
+    await store.startProcessing(key, winnerFp, 60000);
+
+    const wrapped = createLostRaceStore(store);
+    const raceApp = createApp(wrapped);
+    const raceServer = serve({ fetch: raceApp.fetch, port: 0 });
+    await new Promise((resolve) => raceServer.on("listening", resolve));
+    const racePort = raceServer.address().port;
+
+    const response = await makeRequest(racePort, {
+      idempotencyKey: key,
+      body: { foo: "different" }
+    });
+    raceServer.close();
+
+    expect(response.status).toBe(422);
+    expect(response.body.type).toMatch(/#section-2\.2$/);
+    expect(response.body.retryable).toBe(false);
+  });
+
   test("lost race replays 200 when winner already completed", async () => {
     const key = generateIdempotencyKey();
     const fp = await generateFingerprint(JSON.stringify({ foo: "bar" }));

--- a/tests/spec/steps/http-steps.js
+++ b/tests/spec/steps/http-steps.js
@@ -1,4 +1,5 @@
 import { Given, When } from "@cucumber/cucumber";
+import { generateFingerprint } from "../../../packages/core/src/fingerprint.js";
 import { UnavailableIdempotencyStore } from "./unavailable-store.js";
 
 Given(
@@ -47,8 +48,10 @@ Given("the endpoint will delay processing by {int}ms", function (delayMs) {
 });
 
 Given("the key {string} is currently being processed", async function (key) {
-  // Pre-populate store with "processing" state
-  const fingerprint = "test-fingerprint-placeholder";
+  // Pre-populate store with "processing" state for the SAME payload the
+  // concurrent scenarios send ({"foo":"bar"}), so this is a same-payload
+  // retry (-> 409), not a fingerprint-mismatch (which would be -> 422).
+  const fingerprint = await generateFingerprint(JSON.stringify({ foo: "bar" }));
   await this.store.startProcessing(key, fingerprint, 60000);
 });
 


### PR DESCRIPTION
Closes #183

## Problem

In `checkLookupConflicts`, the `byKey.status === "processing"` check (409 "already being processed") ran before the `byKey.fingerprint !== fingerprint` check (422 "reused with different payload"). So a request that loses a `startProcessing` race and re-looks-up the key with a **different body** while the winner is mid-processing received 409 instead of the spec's 422. The ordering existed in the normal lookup path and was inherited by the #181 recheck path.

## Change

Reorder `checkLookupConflicts` so the fingerprint-mismatch check runs first. A same-payload retry still returns 409 (fingerprint matches, so it falls through to the processing check); a different payload returns 422 even while the record is mid-processing. This matches the IETF draft, where 409 is a same-operation retry that is outstanding and 422 is a key reused with a different request payload.

## Tests

- Unit: processing + matching fingerprint -> 409; processing + different fingerprint -> 422.
- Integration lost-race (Redis, MySQL, Postgres, SQLite, bun-sql): loser with a different body -> 422, loser never creates a record.

100% coverage, lint and prettier green; pre-commit hook passes.
