### PR TITLE
feat(core): single-flight coalescing for concurrent same-key requests

### DIFF
--- a/packages/core/src/resilience.js
+++ b/packages/core/src/resilience.js
@@ -65,6 +65,16 @@ export function withResilience(store, options = {}) {
 
   const breaker = new CircuitBreaker(withRetry, breakerOptions);
 
+  /**
+   * In-flight single-flight registry: maps idempotency key to the in-progress
+   * startProcessing promise. Concurrent same-key callers coalesce onto the
+   * first attempt; later callers get IdempotencyKeyExistsError and take the
+   * middleware's existing lost-race path (re-lookup -> 409/replay/422)
+   * instead of issuing a doomed INSERT to the store.
+   * @type {Map<string, Promise<void>>}
+   */
+  const inFlight = new Map();
+
   /** @type {IdempotencyStore} */
   const wrappedStore = {
     /**
@@ -83,7 +93,20 @@ export function withResilience(store, options = {}) {
      * @returns {Promise<void>}
      */
     async startProcessing(key, fingerprint, ttlMs) {
-      return breaker.fire(() => store.startProcessing(key, fingerprint, ttlMs));
+      if (inFlight.has(key)) {
+        throw new IdempotencyKeyExistsError(
+          `startProcessing already in flight for this idempotency key`
+        );
+      }
+      const attempt = breaker.fire(() =>
+        store.startProcessing(key, fingerprint, ttlMs)
+      );
+      inFlight.set(key, attempt);
+      try {
+        return await attempt;
+      } finally {
+        inFlight.delete(key);
+      }
     },
 
     /**

--- a/packages/core/tests/framework-adapter-suite.js
+++ b/packages/core/tests/framework-adapter-suite.js
@@ -299,6 +299,91 @@ export function runAdapterTests(adapter) {
     await teardown();
   });
 
+  // Test: Coalesced loser through the full middleware stack
+  // Two concurrent same-key requests: only the winner's startProcessing
+  // reaches the store; the loser takes the lost-race path (409).
+  test(`${adapter.name} - coalesces concurrent same-key requests`, async (t) => {
+    let startCalls = 0;
+    let lookupCount = 0;
+    const lookupResolvers = [];
+    let resolveWinner;
+    const deferredStore = {
+      lookup: async () => {
+        lookupCount++;
+        // Defer the two initial request lookups so both requests are in
+        // flight before the winner claims the key; the loser's re-lookup
+        // (third call) returns a miss so it takes the 409 branch.
+        if (lookupCount <= 2) {
+          return new Promise((resolve) => {
+            lookupResolvers.push(resolve);
+          });
+        }
+        return { byKey: null, byFingerprint: null };
+      },
+      startProcessing: async () => {
+        startCalls++;
+        return new Promise((resolve) => {
+          resolveWinner = resolve;
+        });
+      },
+      complete: async () => {}
+    };
+
+    const { mount, request, teardown } = await adapter.setup();
+    const middleware = adapter.createMiddleware({ store: deferredStore });
+
+    mount("POST", "/test", middleware, async (req, res) => {
+      return res.send({ ok: true });
+    });
+
+    const requestPromise = () =>
+      request({
+        method: "POST",
+        path: "/test",
+        headers: { "idempotency-key": "coalesce-key-12345678901" },
+        body: { foo: "bar" }
+      });
+
+    const response1 = requestPromise();
+    const response2 = requestPromise();
+
+    const waitFor = async (predicate) => {
+      for (let i = 0; i < 200; i++) {
+        if (predicate()) return;
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      t.fail("timed out waiting for expected middleware state");
+    };
+
+    await waitFor(() => lookupResolvers.length === 2);
+    // Resolve in FIFO order so request 1 claims the key before request 2
+    // reaches startProcessing.
+    lookupResolvers[0]({ byKey: null, byFingerprint: null });
+    lookupResolvers[1]({ byKey: null, byFingerprint: null });
+
+    await waitFor(() => startCalls === 1);
+    resolveWinner();
+
+    const responses = [
+      normalizeResponse(await response1),
+      normalizeResponse(await response2)
+    ];
+    const statuses = responses.map((r) => r.status).sort((a, b) => a - b);
+    t.same(statuses, [200, 409], "exactly one winner (200), one loser (409)");
+    const loser = responses.find((r) => r.status === 409);
+    t.match(
+      loser.body?.error || JSON.stringify(loser.body),
+      /already being processed/i
+    );
+    t.equal(
+      startCalls,
+      1,
+      "store startProcessing should be called exactly once"
+    );
+
+    await teardown();
+  });
+
   // Test: Concurrent processing (explicit state, no timing)
   test(`${adapter.name} - detects concurrent processing with 409`, async (t) => {
     const store = adapter.createStore();

--- a/packages/core/tests/resilience.test.js
+++ b/packages/core/tests/resilience.test.js
@@ -1,6 +1,13 @@
 import { test } from "tap";
 import { withResilience, IdempotencyKeyExistsError } from "@idempot/core";
 
+/** Await a promise while keeping its rejection handled for the test. */
+function wrappedCatch(promise) {
+  return promise.catch((error) => {
+    throw error;
+  });
+}
+
 test("withResilience - wraps store operations", async (t) => {
   let lookupCalled = false;
   let startProcessingCalled = false;
@@ -174,6 +181,187 @@ test("withResilience - circuit breaker opens after failures", async (t) => {
   }
 
   t.ok(circuit.opened, "circuit should be open after failures");
+});
+
+test("withResilience - coalesces concurrent same-key startProcessing", async (t) => {
+  let calls = 0;
+  let resolveWinner;
+  const deferredStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+      return new Promise((resolve) => {
+        resolveWinner = resolve;
+      });
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(deferredStore);
+
+  const winner = store.startProcessing("key", "fp", 60000);
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    IdempotencyKeyExistsError,
+    "concurrent same-key call should get key-exists error without hitting the store"
+  );
+  t.equal(calls, 1, "store startProcessing should be called exactly once");
+
+  resolveWinner();
+  await winner;
+  t.equal(calls, 1, "coalescing should not add store calls");
+});
+
+test("withResilience - concurrent different-key startProcessing does not coalesce", async (t) => {
+  let calls = 0;
+  const countingStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(countingStore);
+
+  await Promise.all([
+    store.startProcessing("key-1", "fp", 60000),
+    store.startProcessing("key-2", "fp", 60000)
+  ]);
+  t.equal(calls, 2, "different keys should each reach the store");
+});
+
+test("withResilience - in-flight entry clears after success", async (t) => {
+  let calls = 0;
+  const countingStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(countingStore);
+
+  await store.startProcessing("key", "fp", 60000);
+  await store.startProcessing("key", "fp", 60000);
+  t.equal(calls, 2, "sequential same-key calls should each reach the store");
+});
+
+test("withResilience - in-flight entry clears after failure", async (t) => {
+  let calls = 0;
+  const failingOnceStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+      if (calls === 1) {
+        throw new Error("Store failure");
+      }
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(failingOnceStore, { maxRetries: 1 });
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    "first call fails"
+  );
+  await store.startProcessing("key", "fp", 60000);
+  t.equal(calls, 2, "same key should reach the store again after failure");
+});
+
+test("withResilience - coalesced loser gets key-exists even when winner fails", async (t) => {
+  let calls = 0;
+  let rejectWinner;
+  const failingWinnerStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+      return new Promise((_resolve, reject) => {
+        rejectWinner = reject;
+      });
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(failingWinnerStore, { maxRetries: 1 });
+
+  const winner = wrappedCatch(store.startProcessing("key", "fp", 60000));
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    IdempotencyKeyExistsError,
+    "loser should get key-exists immediately, regardless of winner outcome"
+  );
+  t.equal(calls, 1, "store should be called once");
+
+  rejectWinner(new Error("Store failure"));
+  await t.rejects(
+    winner,
+    "Store failure",
+    "winner's store error should propagate"
+  );
+});
+
+test("withResilience - concurrent same-key different-fingerprint calls coalesce", async (t) => {
+  let calls = 0;
+  const countingStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(countingStore);
+
+  const winner = store.startProcessing("key", "fp-a", 60000);
+  await t.rejects(
+    store.startProcessing("key", "fp-b", 60000),
+    IdempotencyKeyExistsError,
+    "coalescing is keyed on the idempotency key, not the fingerprint"
+  );
+  await winner;
+  t.equal(calls, 1, "fingerprint difference should not bypass coalescing");
+});
+
+test("withResilience - coalescing guard fires before an open breaker", async (t) => {
+  let calls = 0;
+  let resolveWinner;
+  const mixedStore = {
+    lookup: async () => {
+      throw new Error("Failure");
+    },
+    startProcessing: async () => {
+      calls++;
+      return new Promise((resolve) => {
+        resolveWinner = resolve;
+      });
+    },
+    complete: async () => {}
+  };
+
+  const { store, circuit } = withResilience(mixedStore, {
+    maxRetries: 1,
+    errorThresholdPercentage: 1,
+    volumeThreshold: 1
+  });
+
+  const winner = store.startProcessing("key", "fp", 60000);
+
+  // Open the breaker while the winner's startProcessing is in flight.
+  await t.rejects(store.lookup("other", "fp"), "Failure");
+  t.ok(circuit.opened, "breaker should be open");
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    IdempotencyKeyExistsError,
+    "loser should see key-exists (guard before breaker), not breaker-open"
+  );
+  t.equal(calls, 1);
+
+  resolveWinner();
+  await winner;
 });
 
 test("withResilience - close calls underlying store close", async (t) => {

--- a/packages/stores/bun-sql/README.md
+++ b/packages/stores/bun-sql/README.md
@@ -36,6 +36,8 @@ const mysqlStore = new BunSqlIdempotencyStore(
 | PostgreSQL | `postgres://user:pass@localhost:5432/db`                             |
 | MySQL      | `mysql://user:pass@localhost:3306/db`, `mysql2://...`                |
 
+> **MySQL on Bun >= 1.4:** Bun's MySQL client refuses the `caching_sha2_password` RSA public-key handshake over insecure connections by default. Either pass `allowPublicKeyRetrieval: true` in the store options, or enable TLS on the connection. Bun <= 1.3 and TLS connections are unaffected.
+
 ## API
 
 ### `new BunSqlIdempotencyStore(connectionString, options?)`

--- a/tests/runtime/bun/bun-sql-integration.test.js
+++ b/tests/runtime/bun/bun-sql-integration.test.js
@@ -291,7 +291,11 @@ describe("BunSqlIdempotencyStore with MySQL", () => {
       database: "test"
     });
 
-    store = new BunSqlIdempotencyStore(MYSQL_URL);
+    // Bun >= 1.4 refuses the MySQL caching_sha2_password RSA public-key
+    // handshake over insecure connections unless explicitly allowed.
+    store = new BunSqlIdempotencyStore(MYSQL_URL, {
+      allowPublicKeyRetrieval: true
+    });
     const app = createApp(store);
 
     server = serve({


### PR DESCRIPTION
## Problem

#184: since `IdempotencyKeyExistsError` is excluded from retry and the circuit breaker's `errorFilter`, a hot-key collision storm never backs off. Concurrent losers on the same key each performed a lookup + a guaranteed-failing INSERT + a re-lookup for as long as requests kept arriving — store load unbounded in time.

## Change

Single-flight coalescing inside `withResilience` (`packages/core/src/resilience.js`), so all four framework middlewares inherit it with no changes:

- A per-instance in-flight Map keyed by idempotency key. The first `startProcessing` call for a key reaches the store; concurrent same-key callers get `IdempotencyKeyExistsError` immediately, without a doomed INSERT.
- Coalesced losers take the middlewares' existing lost-race path (re-lookup -> 409 "request is outstanding" / cached replay / 422 fingerprint mismatch), so observable HTTP outcomes are unchanged — verified against SPEC.md 2.6-2.7.
- The in-flight entry clears after both success and failure (try/finally), so sequential requests always reach the store again.
- Per-process scope only: cross-instance serialization remains the store's unique constraint, as documented in #184.

Tests cover the resilience seam (winner-failure, fingerprint independence, open-breaker precedence) and the full middleware path across all four frameworks via `framework-adapter-suite.js`.

## Follow-ups

- Flaky property test observed during review (`validateIdempotencyOptions`, seed 754296080) is tracked in #199 — unrelated to this change.
- No unapplied review findings; the review's testing gaps are covered by this PR's tests.

Fixes #184.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a library release with no production deployment of its own. For consumers: watch store-side INSERT volume on hot idempotency keys (should drop to one per key per processing window) and 409 rates (unchanged expected). Rollback: revert the commit; behavior returns to per-loser INSERTs.
