### PR TITLE
docs: require draft PRs for all changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Run `pnpm run test:verify-coverage` before committing. When trying to learn whic
 
 **Never use `--no-verify` when committing.** This flag bypasses pre-commit hooks that enforce the coverage and linting requirements.
 
+## Git Workflow
+
+**All changes go through a branch and a draft PR, regardless of size.** Never push directly to `main`. If a push reports "bypassed rule violations", the branch protection rule applies: stop and open a draft PR instead. Admin override is not permission.
+
 ## Architecture
 
 - **Language**: JavaScript with JSDoc


### PR DESCRIPTION
Adds a Git Workflow section to AGENTS.md requiring all changes to go through a branch and a draft PR, after a documentation commit was pushed directly to main (94c7073), bypassing branch protection.

<details><summary>Context</summary>
Branch protection on main requires changes to arrive via pull request, but the rule is only enforced at the remote with an admin-override bypass, so it never reached agent instructions. This adds the rule to AGENTS.md where agents actually read it. Matching rules were also added to the global agent config (outside this repo).
</details>
