### PR TITLE
docs: add Context7 ownership claim fields

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/idempot-dev/idempot-js",
+  "public_key": "pk_nYf7Zx5nAEIOsKNOox8S9",
   "projectTitle": "idempot-js",
   "description": "Idempotency middleware for Node.js, Bun, and Deno. Supports Express, Fastify, and Hono with pluggable storage backends including Redis, PostgreSQL, MySQL, SQLite, and Bun SQL.",
   "excludeFolders": ["docs/plans"],


### PR DESCRIPTION
Adds the `url` and `public_key` fields to `context7.json` so Context7 can verify ownership of `/idempot-dev/idempot-js` and grant access to the library admin panel.

After merge: click "Claim Library" on https://context7.com/idempot-dev/idempot-js to complete verification.
