### PR TITLE
test(core): fix flaky valid-options property generator

### DIFF
--- a/packages/core/tests/validation.properties.test.js
+++ b/packages/core/tests/validation.properties.test.js
@@ -21,7 +21,12 @@ const validOptionsArbitrary = () =>
         fc.constant(undefined),
         fc.integer({ min: 1, max: ONE_YEAR_MS })
       ),
-      excludeFields: fc.oneof(fc.constant(undefined), fc.array(fc.string())),
+      excludeFields: fc.oneof(
+        fc.constant(undefined),
+        // validateExcludeFields rejects an entry of exactly "$." as an
+        // invalid JSONPath, so the valid-options model excludes it.
+        fc.array(fc.string().filter((s) => s !== "$."))
+      ),
       store: fc.oneof(fc.constant(undefined), fc.constant(createMockStore())),
       minKeyLength: fc.oneof(
         fc.constant(undefined),


### PR DESCRIPTION
## Problem

#199: the `validateIdempotencyOptions - valid options never throw` property failed intermittently (observed once under a pre-commit coverage run, fast-check seed 754296080). The failure was real but rare: most seeds never generate the triggering input.

## Root cause

The property's valid-options model generated `excludeFields` as any array of strings. `validateExcludeFields` (`packages/core/src/validation.js:86-89`) deliberately rejects an entry of exactly `"$."` as an invalid JSONPath — a behavior that predates the monorepo reorg and is unit-tested. When a random seed produced `"$.`" in the array, the validator legitimately threw and the property failed. A stale test model, not an implementation bug.

## Change

The generator now encodes the real contract: excludeFields entries may be any string except exactly `"$."` (`fc.string().filter(...)`). Verified the recorded seed `754296080` now holds for the full property, and the shrink target (`["$."]`) is no longer generated.

Fixes #199. The issue's second item — the one-off `resilience.test.js` transient under parallel coverage instrumentation — remains unreproducible (3/3 isolated runs, full suite, and pre-commit coverage gate green) and stays as a watch-in-CI item rather than a fix.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — test-only change, no runtime behavior touched.
