### PR TITLE
fix: shorten context7.json rule to satisfy schema limit

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -7,7 +7,8 @@
   "excludeFolders": ["docs/plans"],
   "excludeFiles": ["AGENTS.md"],
   "rules": [
-    "Install one framework middleware package (@idempot/express-middleware, @idempot/fastify-middleware, @idempot/hono-middleware, or @idempot/bun-handler) plus one store package (@idempot/redis-store, @idempot/postgres-store, @idempot/mysql-store, @idempot/sqlite-store, or @idempot/bun-sql-store). @idempot/core is a transitive dependency, not installed directly.",
+    "Install one framework middleware package: @idempot/express-middleware, @idempot/fastify-middleware, @idempot/hono-middleware, or @idempot/bun-handler.",
+    "Install one store package: @idempot/redis-store, @idempot/postgres-store, @idempot/mysql-store, @idempot/sqlite-store, or @idempot/bun-sql-store. @idempot/core is transitive; do not install it directly.",
     "Create a store instance and pass it to the idempotency() middleware via the store option.",
     "Implements the IETF draft-ietf-httpapi-idempotency-key-header-07 specification. Clients send the Idempotency-Key header on requests that must not run twice.",
     "Error responses follow RFC 9457 (Problem Details) with content negotiation via the Accept header; application/problem+json is the default.",


### PR DESCRIPTION
The first entry in `rules` exceeded the 255-character per-item limit in the [context7.json schema](https://context7.com/schema/context7.json), which made library claiming fail with "context7.json format is incorrect for claiming". The rule is split into two entries; the file now validates against the schema.

<details><summary>Diagnosis</summary>
The claiming error message ("Requires url and public_key. Known config fields are allowed, but unknown fields are not") is generic and does not name the failing field. Validating the file against the published schema showed rules[0] at 360 characters vs maxLength 255. All other fields, including url and public_key, were already valid.
</details>
