### PR TITLE
fix: stop retrying write operations in withResilience

### DIFF
--- a/packages/core/src/resilience.js
+++ b/packages/core/src/resilience.js
@@ -63,7 +63,11 @@ export function withResilience(store, options = {}) {
     throw lastError;
   };
 
-  const breaker = new CircuitBreaker(withRetry, breakerOptions);
+  const breaker = new CircuitBreaker(
+    async (operation, shouldRetry) =>
+      shouldRetry ? withRetry(operation) : operation(),
+    breakerOptions
+  );
 
   /**
    * In-flight single-flight registry: maps idempotency key to the in-progress
@@ -83,7 +87,8 @@ export function withResilience(store, options = {}) {
      * @returns {Promise<{byKey: import("./store/interface.js").IdempotencyRecord | null, byFingerprint: import("./store/interface.js").IdempotencyRecord | null}>}
      */
     async lookup(key, fingerprint) {
-      return breaker.fire(() => store.lookup(key, fingerprint));
+      // Reads are safe to retry.
+      return breaker.fire(() => store.lookup(key, fingerprint), true);
     },
 
     /**
@@ -98,8 +103,9 @@ export function withResilience(store, options = {}) {
           `startProcessing already in flight for this idempotency key`
         );
       }
-      const attempt = breaker.fire(() =>
-        store.startProcessing(key, fingerprint, ttlMs)
+      const attempt = breaker.fire(
+        () => store.startProcessing(key, fingerprint, ttlMs),
+        false
       );
       inFlight.set(key, attempt);
       try {
@@ -115,7 +121,10 @@ export function withResilience(store, options = {}) {
      * @returns {Promise<void>}
      */
     async complete(key, response) {
-      return breaker.fire(() => store.complete(key, response));
+      // Writes are never retried: if the first attempt commits but the caller
+      // never sees success, a retried write hits the unique constraint and
+      // turns the indeterminate commit into a false 409 conflict (issue #185).
+      return breaker.fire(() => store.complete(key, response), false);
     },
 
     async close() {

--- a/packages/core/tests/problem-json.test.js
+++ b/packages/core/tests/problem-json.test.js
@@ -65,6 +65,15 @@ describe("problem-json", () => {
       assert.strictEqual(result.retryable, false);
       assert.strictEqual(result.status, 422);
     });
+
+    it("should include idempotency_key when provided", () => {
+      const result = conflictErrorResponse(409, "Fingerprint conflict", {
+        instance: "urn:uuid:test-key",
+        idempotencyKey: "my-key"
+      });
+
+      assert.strictEqual(result.idempotency_key, "my-key");
+    });
   });
 
   describe("storeUnavailableResponse", () => {

--- a/packages/core/tests/resilience.test.js
+++ b/packages/core/tests/resilience.test.js
@@ -136,6 +136,91 @@ test("withResilience - key-exists error keeps the circuit closed", async (t) => 
   );
 });
 
+test("withResilience - writes are not retried on failure", async (t) => {
+  let startAttempts = 0;
+  let completeAttempts = 0;
+  const failingWriteStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      startAttempts++;
+      throw new Error("Temporary failure");
+    },
+    complete: async () => {
+      completeAttempts++;
+      throw new Error("Temporary failure");
+    }
+  };
+
+  const { store } = withResilience(failingWriteStore, { maxRetries: 3 });
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    "Temporary failure"
+  );
+  await t.rejects(
+    store.complete("key", { status: 200, headers: {}, body: "" }),
+    "Temporary failure"
+  );
+  t.equal(startAttempts, 1, "startProcessing should not be retried");
+  t.equal(completeAttempts, 1, "complete should not be retried");
+});
+
+test("withResilience - indeterminate write commit is not retried into a false duplicate", async (t) => {
+  // Simulates the indeterminate-commit ambiguity: first attempt commits on the
+  // store but the error hides it; a retry would hit the unique constraint and
+  // surface as a false 409 conflict.
+  let committed = false;
+  let storeCalls = 0;
+  const indeterminateStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      storeCalls++;
+      if (!committed) {
+        committed = true;
+        throw new Error("Connection reset");
+      }
+      throw new IdempotencyKeyExistsError("duplicate key");
+    },
+    complete: async () => {}
+  };
+
+  const { store } = withResilience(indeterminateStore, { maxRetries: 3 });
+
+  await t.rejects(
+    store.startProcessing("key", "fp", 60000),
+    "Connection reset",
+    "caller should see the transient error, not a duplicate-key 409"
+  );
+  t.equal(storeCalls, 1, "the committed write must never be re-issued");
+});
+
+test("withResilience - writes still trip the circuit breaker", async (t) => {
+  let calls = 0;
+  const failingWriteStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {
+      calls++;
+      throw new Error("Failure");
+    },
+    complete: async () => {}
+  };
+
+  const { store, circuit } = withResilience(failingWriteStore, {
+    maxRetries: 1,
+    errorThresholdPercentage: 1,
+    volumeThreshold: 1
+  });
+
+  try {
+    await store.startProcessing("key", "fp", 60000);
+  } catch {
+    // Expected
+  }
+
+  t.equal(calls, 1, "write should reach the store once");
+  t.ok(circuit.opened, "circuit should open after write failures");
+});
+
 test("withResilience - respects timeout", async (t) => {
   const slowStore = {
     lookup: async () => {

--- a/packages/core/tests/resilience.test.js
+++ b/packages/core/tests/resilience.test.js
@@ -268,6 +268,33 @@ test("withResilience - circuit breaker opens after failures", async (t) => {
   t.ok(circuit.opened, "circuit should be open after failures");
 });
 
+test("withResilience - complete failures trip the circuit breaker", async (t) => {
+  let calls = 0;
+  const failingCompleteStore = {
+    lookup: async () => ({ byKey: null, byFingerprint: null }),
+    startProcessing: async () => {},
+    complete: async () => {
+      calls++;
+      throw new Error("Failure");
+    }
+  };
+
+  const { store, circuit } = withResilience(failingCompleteStore, {
+    maxRetries: 1,
+    errorThresholdPercentage: 1,
+    volumeThreshold: 1
+  });
+
+  try {
+    await store.complete("key", { status: 200, headers: {}, body: "" });
+  } catch {
+    // Expected
+  }
+
+  t.equal(calls, 1, "complete should reach the store once");
+  t.ok(circuit.opened, "circuit should open after complete failures");
+});
+
 test("withResilience - coalesces concurrent same-key startProcessing", async (t) => {
   let calls = 0;
   let resolveWinner;


### PR DESCRIPTION
## Summary

`withResilience` no longer retries write operations (`startProcessing`, `complete`); only `lookup` keeps the retry + circuit-breaker loop. This removes the indeterminate-commit path where a retried write hit the unique constraint and surfaced as a false 409 "already being processed by a concurrent request" for the request that actually owns the record.

Fixes #185. Follow-up to #181.

## Changes

- `packages/core/src/resilience.js`: the breaker action now takes a retry flag. `lookup` passes `true`; `startProcessing` and `complete` pass `false`, so a write that fails after committing is never re-issued.
- Tests: writes are not retried on transient failure; an indeterminate commit (first attempt commits but throws) is reported as the transient error, not a duplicate; write failures still trip the circuit breaker.
- Also covers the previously untested `idempotency_key` branch in `conflictErrorResponse` (pre-existing 100%-coverage gap on `main`).

## Spec compliance

No deviation. The spec's 409 "conflict" contract still applies to genuine concurrent requests; this change only stops mislabelling a request's own indeterminate commit as a conflict. The coalescing guard and lost-race 409/replay/422 paths are unchanged.

## Detail

The bug: a write commits on the store but the connection drops before the caller sees success. The retry loop re-ran the INSERT, hit the unique constraint, and short-circuited to `IdempotencyKeyExistsError`, which the middleware translated into 409 "already being processed". The true winner was treated as a concurrent loser, its handler never ran, and the record stayed `processing` for the full TTL. Because `IdempotencyKeyExistsError` is excluded from the breaker's `errorFilter`, the false 409 did not even register as a failure.

Trade-off: a genuinely transient write failure now fails immediately instead of retrying. That is the safe direction — a failed write is visible (503, retryable by the client), whereas a retried write is ambiguous.

<details><summary>Verification</summary>

- `pnpm run test:verify-coverage-min` (pre-commit hook) green on both commits.
- `pnpm run check`: eslint clean; prettier clean on changed files (remaining warnings are untracked local artifacts).
- One flaky failure of the vendored bun sqlite-store test under parallel load, unrelated to this change; passes in isolation and on rerun.

</details>