### PR TITLE
fix(bun-sql): create schema DDL once per store instance

### DIFF
--- a/packages/stores/bun-sql/index.js
+++ b/packages/stores/bun-sql/index.js
@@ -37,6 +37,14 @@ export class BunSqlIdempotencyStore {
   isPostgres;
 
   /**
+   * Set after the first successful ensureSchema() so DDL runs once per store
+   * instead of on every operation.
+   *
+   * @type {boolean}
+   */
+  schemaReady;
+
+  /**
    * @param {string} connectionString - Database connection string or path
    * @param {BunSqlIdempotencyStoreOptions} [options]
    */
@@ -44,6 +52,7 @@ export class BunSqlIdempotencyStore {
     this.isSqlite = this.isSqliteConnection(connectionString);
     this.isMySQL = this.isMySqlConnection(connectionString);
     this.isPostgres = this.isPostgresConnection(connectionString);
+    this.schemaReady = false;
 
     if (this.isSqlite) {
       const sqlitePath = this.normalizeSqlitePath(connectionString);
@@ -169,11 +178,14 @@ export class BunSqlIdempotencyStore {
    * @returns {Promise<void>}
    */
   async ensureSchema() {
-    if (!this.isSqlite) {
-      const keyColumn = this.isMySQL ? "`key`" : '"key"';
+    if (this.isSqlite || this.schemaReady) {
+      return;
+    }
 
-      if (this.isMySQL) {
-        await this.db.unsafe(`
+    const keyColumn = this.isMySQL ? "`key`" : '"key"';
+
+    if (this.isMySQL) {
+      await this.db.unsafe(`
           CREATE TABLE IF NOT EXISTS idempotency_records (
             ${keyColumn} VARCHAR(255) PRIMARY KEY,
             fingerprint VARCHAR(255) NOT NULL,
@@ -184,8 +196,8 @@ export class BunSqlIdempotencyStore {
             expires_at BIGINT NOT NULL
           )
         `);
-      } else {
-        await this.db.unsafe(`
+    } else {
+      await this.db.unsafe(`
           CREATE TABLE IF NOT EXISTS idempotency_records (
             ${keyColumn} TEXT PRIMARY KEY,
             fingerprint TEXT NOT NULL,
@@ -196,22 +208,23 @@ export class BunSqlIdempotencyStore {
             expires_at BIGINT NOT NULL
           )
         `);
-      }
-
-      try {
-        await this
-          .db`CREATE INDEX idx_fingerprint ON idempotency_records(fingerprint)`;
-      } catch {
-        // Index already exists, ignore
-      }
-
-      try {
-        await this
-          .db`CREATE INDEX idx_expires_at ON idempotency_records(expires_at)`;
-      } catch {
-        // Index already exists, ignore
-      }
     }
+
+    try {
+      await this
+        .db`CREATE INDEX idx_fingerprint ON idempotency_records(fingerprint)`;
+    } catch {
+      // Index already exists, ignore
+    }
+
+    try {
+      await this
+        .db`CREATE INDEX idx_expires_at ON idempotency_records(expires_at)`;
+    } catch {
+      // Index already exists, ignore
+    }
+
+    this.schemaReady = true;
   }
 
   /**

--- a/tests/runtime/bun/bun-sql.test.js
+++ b/tests/runtime/bun/bun-sql.test.js
@@ -136,6 +136,37 @@ describe("BunSqlIdempotencyStore", () => {
     });
   });
 
+  describe("schema management", () => {
+    test("runs schema DDL once per store instance", async () => {
+      const store = new BunSqlIdempotencyStore(
+        "mysql://user:pass@localhost:3306/test"
+      );
+      const statements = [];
+      const db = (strings) => {
+        statements.push(strings.join("?"));
+        return Promise.resolve([]);
+      };
+      db.unsafe = (sql) => {
+        statements.push(sql);
+        if (sql.startsWith("UPDATE")) return Promise.resolve({ changes: 1 });
+        return Promise.resolve([[]]);
+      };
+      db.close = () => {};
+      store.db = db;
+
+      await store.lookup("key1", "fp1");
+      await store.startProcessing("key1", "fp1", 60000);
+      await store.complete("key1", { status: 200, headers: {}, body: "" });
+      await store.lookup("key2", "fp2");
+
+      const ddlCount = statements.filter((sql) =>
+        sql.includes("CREATE ")
+      ).length;
+      expect(ddlCount).toBe(3); // table + 2 indexes, once
+      store.close();
+    });
+  });
+
   describe("close", () => {
     test("closes database connection", () => {
       const tempStore = new BunSqlIdempotencyStore("sqlite://:memory:");


### PR DESCRIPTION
## Summary

`ensureSchema()` in the bun-sql store re-issued `CREATE TABLE IF NOT EXISTS` plus two `CREATE INDEX` statements on every `lookup`, `startProcessing`, and `complete` call. It now runs once per store instance, guarded by a `schemaReady` flag.

Fixes #205.

## Why it matters

Every idempotency request paid for three DDL round trips before its actual query, and every request was exposed to MySQL DDL failure modes (metadata lock contention, implicit-commit races) that plain DML does not hit. A transient DDL error made the operation throw, which the middleware surfaces as 503. This flaked CI on #204 (run 34024858188: "conflict with same fingerprint different key" got 503 instead of 409, green on rerun with an identical tree); PR #204's removal of write retries had removed the retry masking that hid the flake.

## Changes

- `packages/stores/bun-sql/index.js`: `schemaReady` flag set after the first successful `ensureSchema()`; subsequent calls return immediately. SQLite keeps its constructor-time schema and skips the path entirely.
- `tests/runtime/bun/bun-sql.test.js`: new unit test asserting DDL executes exactly once (table + 2 indexes) across four operations against a stubbed MySQL client. Failed before the fix (12 DDL statements observed).

<details><summary>Verification</summary>

- New test red before the fix (12 DDL statements), green after (3).
- Full bun suite green locally, including the MySQL integration file against a live local MySQL (32 tests, 0 failures).
- Root gate `pnpm run test:verify-coverage-min` green (pre-commit hook).

</details>