### PR TITLE
fix(tap): exclude nested node_modules from test file discovery

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -9,6 +9,7 @@ files:
 
 exclude:
   - "node_modules/**"
+  - "**/node_modules/**"
   - "**/shared/*.js"
   - "tests/integration/shared/"
   - "tests/runtime/bun/bun-sql-integration.test.js"


### PR DESCRIPTION
Fixes a flaky `ENOENT: unlink './idempotency.db'` failure in `test:verify-coverage-min`.

**Root cause:** the `.taprc` include glob `packages/frameworks/**/*.test.js` matches test files reached through pnpm workspace symlinks inside `node_modules` (for example `packages/frameworks/express/node_modules/@idempot/sqlite-store/sqlite.test.js`, which resolves back to `packages/stores/sqlite/sqlite.test.js`). The existing `exclude: node_modules/**` only matches a root-level `node_modules`, so tap ran the same file twice in parallel. The sqlite store's default path is the CWD-relative `./idempotency.db`, so the two workers raced on one physical file; whichever worker ran its cleanup `unlinkSync` second threw `ENOENT`.

**Change:** add `**/node_modules/**` to the exclude list (the original root-level pattern stays). Symlinked duplicates no longer run; the real test files still run and still feed coverage.

**Verification:** two consecutive `test:verify-coverage-min` runs pass at 100% coverage on this branch, where the duplicate previously made the gate fail roughly once every few runs locally. CI stayed green only by scheduling luck.

<details>
<summary>All duplicates reachable through node_modules symlinks (same file as a real test elsewhere)</summary>

- `packages/frameworks/express/node_modules/@idempot/sqlite-store/sqlite.test.js` → `packages/stores/sqlite/sqlite.test.js`
- `packages/frameworks/bun/node_modules/@idempot/core/tests/fingerprint.test.js` → `packages/core/tests/fingerprint.test.js`
- `packages/frameworks/fastify/node_modules/@idempot/core/tests/errors.test.js` → `packages/core/tests/errors.test.js`
- `packages/frameworks/hono/node_modules/@idempot/core/tests/validation.properties.test.js` → `packages/core/tests/validation.properties.test.js`
- `packages/stores/redis/node_modules/@idempot/core/tests/content-negotiation.test.js` → `packages/core/tests/content-negotiation.test.js`
- `packages/frameworks/fastify/node_modules/fastify/test/conditional-pino.test.js` (upstream fastify test, also matched by the framework glob)

Excluding these also stops the duplicated execution time and coverage double-counting they caused.
</details>
